### PR TITLE
fix: convert LaTeX math to AsciiMath in stem blocks

### DIFF
--- a/sources/d011-e13/sections/03-instructions.adoc
+++ b/sources/d011-e13/sections/03-instructions.adoc
@@ -12,7 +12,7 @@ The applicable Recommendation shall specify, for each category or subcategory of
 
 NOTE: The applicable Recommendation may indicate that individual subcategories of measuring instruments may have different rated operating conditions, reference conditions and limits of disturbances.
 
-NOTE: Rated operating conditions are generally specified as a range (for example: stem:[-10\,\mathrm{°C}] to stem:[+40\,\mathrm{°C}]); reference conditions are generally specified as a single value with a range of variation (for example: stem:[23\,\mathrm{°C} \pm 2\,\mathrm{°C}]).
+NOTE: Rated operating conditions are generally specified as a range (for example: stem:[-10 "unitsml(degC)"] to stem:[+40 "unitsml(degC)"]); reference conditions are generally specified as a single value with a range of variation (for example: stem:[23 "unitsml(degC)" +- 2 "unitsml(degC)"]).
 
 NOTE: The reference conditions shall preferably be specified in accordance with <<IEC60068-1>>.
 

--- a/sources/d011-e13/sections/08-performance-tests.adoc
+++ b/sources/d011-e13/sections/08-performance-tests.adoc
@@ -146,7 +146,7 @@ The following test and evaluation sequence is recommended when NSAa evaluation i
 . Establish the period of time needed per measurement;
 . Start the measurements under reference conditions;
 . Stop the measurements after the period of time established and keep the EUT switched on;
-. Determine the initial intrinsic error (stem:[E_{ii}]);
+. Determine the initial intrinsic error (stem:[E_(ii)]);
 . Record all indicated and registered values of interest;
 . Only when applicable: switch off the EUT (see note 1);
 . Activate the disturbance generator;

--- a/sources/d011-e13/sections/11-external-wiring.adoc
+++ b/sources/d011-e13/sections/11-external-wiring.adoc
@@ -65,8 +65,8 @@ Information to be presented in the applicable Recommendation, where relevant
 |===
 | Test level index | 1
 
-| Mains voltage footnote:[For three phase mains power supplies, the voltage variation is applicable for each of the phases successively.] footnote:[The values of stem:[U_nom] are those as marked on the measuring instrument. If a range is specified, stem:[U_{nom1}] concerns the highest and stem:[U_{nom2}] concerns the lowest value in the range. If only one nominal mains voltage value (stem:[U_nom]) is specified then stem:[U_{nom1} = U_{nom2} = U_nom].] | Upper limit | stem:[U_{nom1}] + 10 %
-| | Lower limit | stem:[U_{nom2}] - 15 %
+| Mains voltage footnote:[For three phase mains power supplies, the voltage variation is applicable for each of the phases successively.] footnote:[The values of stem:[U_nom] are those as marked on the measuring instrument. If a range is specified, stem:[U_(nom1)] concerns the highest and stem:[U_(nom2)] concerns the lowest value in the range. If only one nominal mains voltage value (stem:[U_nom]) is specified then stem:[U_(nom1) = U_(nom2) = U_nom].] | Upper limit | stem:[U_(nom1)] + 10 %
+| | Lower limit | stem:[U_(nom2)] - 15 %
 |===
 
 [[table-21]]
@@ -84,8 +84,8 @@ Information to be presented in the applicable Recommendation, where relevant
 |===
 | Test level index | 1
 
-| Mains frequency | Upper limit | stem:[f_{nom}] + 2 %
-| | Lower limit | stem:[f_{nom}] - 2 %
+| Mains frequency | Upper limit | stem:[f_(nom)] + 2 %
+| | Lower limit | stem:[f_(nom)] - 2 %
 |===
 
 === Mains power disturbances

--- a/sources/d011-e13/sections/12-electromagnetic.adoc
+++ b/sources/d011-e13/sections/12-electromagnetic.adoc
@@ -21,8 +21,8 @@ See 8.4.2.9 for applicability (also refer to 4.4).
 |===
 | Test level index footnote:[The test levels considered most appropriate and preferable for OIML Recommendations are presented in bold face.] | 1 | 2 | 3 | *4* | *5* | i footnote:["+i" and "stem:[H_xi]" are variables indicating that alternative field strength levels may be specified in the applicable Recommendation if accompanied by a rationale for such choice.] | unit footnote:[The magnetic field strength is expressed in A/m. 1 A/m corresponds to a free space magnetic flux density of 1.26 μT.]
 
-| Magnetic field strength: continuous field | 1 | 3 | 10 | *30* | *100* | stem:[H_{1i}] | A/m
-| Magnetic field strength: short duration (1 s to 3 s) | n/a | n/a | n/a | *300* | *1000* | stem:[H_{2i}] | A/m
+| Magnetic field strength: continuous field | 1 | 3 | 10 | *30* | *100* | stem:[H_(1i)] | A/m
+| Magnetic field strength: short duration (1 s to 3 s) | n/a | n/a | n/a | *300* | *1000* | stem:[H_(2i)] | A/m
 |===
 
 Information to be presented in the applicable Recommendation, where relevant

--- a/sources/r060/1/sections/03-terminology.adoc
+++ b/sources/r060/1/sections/03-terminology.adoc
@@ -202,7 +202,7 @@ method, manufacturing method);
 voltage, cable details); and
 
 . one or more load cell groups where all load cells within the group possess identical
-metrological characteristics (as listed in <<sec-5.1.5>> -- including: class; stem:[n_{"LC"}];
+metrological characteristics (as listed in <<sec-5.1.5>> -- including: class; stem:[n_("LC")];
 temperature rating, etc.).
 
 NOTE: The examples provided are not intended to be limiting.
@@ -217,10 +217,10 @@ subdivision of the load cell measuring range
 
 ==== load cell measuring range (for verification)
 
-range between the maximum load of the measuring range stem:[D_{"max"}] and minimum
-load of the measuring range stem:[D_{"min"}]
+range between the maximum load of the measuring range stem:[D_("max")] and minimum
+load of the measuring range stem:[D_("min")]
 
-load cell measuring range stem:[= (D_{"max"} - D_{"min"}])
+load cell measuring range stem:[= (D_("max") - D_("min")])
 
 ==== load cell output
 
@@ -232,13 +232,13 @@ load cell interval, expressed in units of mass, used in the test of the load cel
 for accuracy classification
 
 [[sec-3.5.5]]
-==== maximum capacity (stem:[E_{"max"}])
+==== maximum capacity (stem:[E_("max")])
 
 largest value of a quantity expressed in units of mass, which may be applied to a
 load cell
 
 [[sec-3.5.6]]
-==== maximum load of the measuring range (stem:[D_{"max"])
+==== maximum load of the measuring range (stem:[D_("max")])
 
 largest value of a quantity expressed in units of mass which can be introduced to
 a load cell under test
@@ -248,19 +248,19 @@ a load cell under test
 range of values of the quantity expressed in units of mass that may be applied to
 a load cell
 
-NOTE: maximum measuring range is the range between maximum capacity stem:[E_{"max"}]
-and minimum dead load stem:[E_{"min"}]
+NOTE: maximum measuring range is the range between maximum capacity stem:[E_("max")]
+and minimum dead load stem:[E_("min")]
 
-maximum measuring range stem:[= (E_{"max"} - E_{"min"})]
+maximum measuring range stem:[= (E_("max") - E_("min"))]
 
 [[sec-3.5.8]]
-==== maximum number of load cell verification intervals (stem:[n_{"LC"}])
+==== maximum number of load cell verification intervals (stem:[n_("LC")])
 
 maximum number of load cell verification intervals into which the maximum measuring
 range may be divided
 
 [[sec-3.5.9]]
-==== minimum dead load (stem:[E_{"min"}])
+==== minimum dead load (stem:[E_("min")])
 
 smallest value of a quantity (expressed in mass units) that may be applied to a load
 cell
@@ -269,16 +269,16 @@ cell
 ==== minimum dead load output return (DR)
 
 difference of load cell output, expressed in units of mass at the minimum dead load
-(stem:[D_{"min"}]), measured before and after application of a load of stem:[D_{"max"}]
+(stem:[D_("min")]), measured before and after application of a load of stem:[D_("max")]
 
 [[sec-3.5.11]]
-==== minimum load cell verification interval (stem:[v_{"min"}])
+==== minimum load cell verification interval (stem:[v_("min")])
 
 smallest load cell verification interval in units of mass into which the maximum
-measuring range (stem:[E_{"max"} - E_{"min"}]) can be divided
+measuring range (stem:[E_("max") - E_("min")]) can be divided
 
 [[sec-3.5.12]]
-==== minimum load of the measuring range (stem:[D_{"min"}])
+==== minimum load of the measuring range (stem:[D_("min")])
 
 smallest value of a quantity expressed in units of mass, applied to a load cell under
 test
@@ -299,12 +299,12 @@ NOTE: This ratio is used to describe multi-interval instruments.
 ==== relative minimum load cell verification interval (stem:[Y])
 
 ratio of the maximum measuring range, to the minimum load cell verification interval,
-stem:[v_{"min"}]
+stem:[v_("min")]
 
 NOTE: This ratio describes the resolution of the load cell independent from the load
 cell capacity.
 
-==== safe load limit (stem:[E_{"lim"}])
+==== safe load limit (stem:[E_("lim")])
 
 maximum load that can be applied without producing a permanent shift in the performance
 characteristics beyond those specified
@@ -317,10 +317,10 @@ load cell is capable of complying with the requirements
 [[sec-3.6]]
 === Illustration of certain definitions
 
-The terms that appear above the central horizontal line (related to parameters stem:[E_{"min"}]
-and stem:[E_{"max"}]) are parameters that are fixed by the design of the load cell.
-The terms that appear below that line (related to parameters stem:[D_{"min"}] and
-stem:[D_{"max"}]) are parameters that are variable, dependent on the conditions of
+The terms that appear above the central horizontal line (related to parameters stem:[E_("min")]
+and stem:[E_("max")]) are parameters that are fixed by the design of the load cell.
+The terms that appear below that line (related to parameters stem:[D_("min")] and
+stem:[D_("max")]) are parameters that are variable, dependent on the conditions of
 the test of a load cell (in particular, those load cells used in weighing instruments).
 
 .Illustration of certain definitions
@@ -328,9 +328,9 @@ image::figure-3.svg[]
 
 The following statements apply: (see also R 60-2, 2.7.3.4)
 
-. stem:[(D_{"max"} - D_{"min"})  (E_{"max"} - E_{"min"})]
+. stem:[(D_("max") - D_("min"))  (E_("max") - E_("min"))]
 
-. stem:[E_{"min"} <= D_{"min"} <= (0.1 E_{"max"})], and stem:[(0.9 E_{"max"}) <= D_{"max"} <= E_{"max"}]
+. stem:[E_("min") <= D_("min") <= (0.1 E_("max"))], and stem:[(0.9 E_("max")) <= D_("max") <= E_("max")]
 
 [heading="terms and definitions"]
 === Measurement and error terms
@@ -340,7 +340,7 @@ The following statements apply: (see also R 60-2, 2.7.3.4)
 change in load cell output occurring with time while under constant load and with
 all environmental conditions and other variables also remaining constant
 
-==== apportioning factor (stem:[p_{"LC"}])
+==== apportioning factor (stem:[p_("LC")])
 
 value of a dimensionless fraction expressed as a decimal (for example, 0.7) representing
 that portion of an error observed in the (weighing) instrument which is attributed
@@ -377,8 +377,8 @@ electrical representation issued by the load cell indicating that a fault condit
 ==== hysteresis error
 
 difference in load cell output readings for the same applied force between the reading
-obtained by increasing the load from minimum load (stem:[D_{"min"}]), and the reading
-obtained by decreasing the load from maximum load (stem:[D_{"max"}])
+obtained by increasing the load from minimum load (stem:[D_("min")]), and the reading
+obtained by decreasing the load from maximum load (stem:[D_("max")])
 
 ==== initial intrinsic error
 

--- a/sources/r060/1/sections/05-metrological-requirements.adoc
+++ b/sources/r060/1/sections/05-metrological-requirements.adoc
@@ -26,12 +26,12 @@ Class A; Class B; Class C; Class D.
 [[sec-5.1.2]]
 ==== Maximum number of load cell verification intervals
 
-The maximum number of load cell verification intervals, stem:[n_{"LC"}], into which
-the maximum measuring range stem:[E_{"max"} - E_{"min"}] (see <<sec-3.5.8>>) can
+The maximum number of load cell verification intervals, stem:[n_("LC")], into which
+the maximum measuring range stem:[E_("max") - E_("min")] (see <<sec-3.5.8>>) can
 be divided in a measuring system shall be within the limits presented in <<table-1>>.
 
 [[table-1]]
-.Maximum number of load cell verification intervals (stem:[n_{"LC"}]) according to accuracy class
+.Maximum number of load cell verification intervals (stem:[n_("LC")]) according to accuracy class
 [cols="5*^",options="header"]
 |===
 | | Class A | Class B | Class C | Class D
@@ -41,7 +41,7 @@ be divided in a measuring system shall be within the limits presented in <<table
 
 ==== Minimum load cell verification interval
 
-The minimum load cell verification interval, stem:[v_{"min"}], shall be specified
+The minimum load cell verification interval, stem:[v_("min")], shall be specified
 by the manufacturer (see <<sec-3.5.11>> in combination with <<sec-3.5.15>>).
 
 [[sec-5.1.4]]
@@ -116,15 +116,15 @@ classification symbols, using an example, is shown in <<fig-4>>.
 
 === Measuring ranges
 
-==== Minimum load of the measuring range (stem:[D_{"min"}]) (see <<sec-3.5.12>>)
+==== Minimum load of the measuring range (stem:[D_("min")]) (see <<sec-3.5.12>>)
 
 The value of the smallest load applied to a load cell during test which is expressed
-in units of mass shall not be less than stem:[E_{"min"}] (see <<sec-3.5.9>>).
+in units of mass shall not be less than stem:[E_("min")] (see <<sec-3.5.9>>).
 
-==== Maximum load of the measuring range (stem:[D_{"max"}]) (see <<sec-3.5.6>>)
+==== Maximum load of the measuring range (stem:[D_("max")]) (see <<sec-3.5.6>>)
 
 The value of the largest load applied to a load cell during test which is expressed
-in units of mass shall not be greater than stem:[E_{"max"}] (see <<sec-3.5.5>>).
+in units of mass shall not be greater than stem:[E_("max")] (see <<sec-3.5.5>>).
 
 [[sec-5.3]]
 === Maximum permissible measurement errors
@@ -138,7 +138,7 @@ The MPE is applicable after increasing as well as decreasing the force applied
 ==== Maximum permissible errors for each accuracy class
 
 The maximum permissible measurement errors for each accuracy class are related to
-the maximum number of load cell verification intervals (stem:[n_{"LC"}]) specified
+the maximum number of load cell verification intervals (stem:[n_("LC")]) specified
 for the load cell (see <<sec-5.1.2>>) and to the actual value of the load cell verification
 interval, stem:[v].
 
@@ -147,8 +147,8 @@ interval, stem:[v].
 
 The MPE (see <<sec-3.7.10>>) on type evaluation shall be the values derived using
 the expressions contained in the left column of <<table-4>>. The apportioning factor,
-stem:[p_{"LC"}] shall be chosen and declared (if other than 0.7) by the manufacturer
-and shall be in the range of 0.3 to 0.8: (stem:[0.3 <= p_{"LC"} <= 0.8])
+stem:[p_("LC")] shall be chosen and declared (if other than 0.7) by the manufacturer
+and shall be in the range of 0.3 to 0.8: (stem:[0.3 <= p_("LC") <= 0.8])
 footnote:[Associated with apportionment of error provisions contained within OIML
 <<OIML_R_76_1,clause="3.5.1">> and <<OIML_R_76_1,clause="3.10.2.1">>; <<OIML_R_50_1,clause="2.2.33.2.2">>; <<OIML_R_51_1,clause="5.2.3.4">>;
 <<OIML_R_61_1,clause="5.2.3.3">>; <<OIML_R_106_1,clause="5.1.3.2">>; or <<OIML_R_107_1,clause="5.1.4.1">>, when load
@@ -163,13 +163,13 @@ representing the force introduced by the load applied.
 (+/-)
 4+| Load, stem:[m]
 | Class A | Class B | Class C | Class D
-| stem:[p_{"LC"} xx 0.5 " v"] | stem:[0 <= m <= 50000 " v"] | stem:[0 <= m <= 5000 " v"] | stem:[0 <= m <= 500 " v"] | stem:[0 <= m <= 50 " v"]
-| stem:[p_{"LC"} xx 1.0 " v"] | stem:[50000 " v" < m <= 200 000 " v"] | stem:[5000 " v" < m <= 20 000 " v"] | stem:[500 " v" < m <= 2 000 " v"] | stem:[50 " v" < m <= 200 " v"]
-| stem:[p_{"LC"} xx 1.5 " v"] | stem:[200000 " v" < m] | stem:[20000 " v" < m <= 100 000 " v"] | stem:[2000 " v" < m <= 10000 " v"] | stem:[200 " v" < m <= 1 000 " v"]
+| stem:[p_("LC") xx 0.5 " v"] | stem:[0 <= m <= 50000 " v"] | stem:[0 <= m <= 5000 " v"] | stem:[0 <= m <= 500 " v"] | stem:[0 <= m <= 50 " v"]
+| stem:[p_("LC") xx 1.0 " v"] | stem:[50000 " v" < m <= 200 000 " v"] | stem:[5000 " v" < m <= 20 000 " v"] | stem:[500 " v" < m <= 2 000 " v"] | stem:[50 " v" < m <= 200 " v"]
+| stem:[p_("LC") xx 1.5 " v"] | stem:[200000 " v" < m] | stem:[20000 " v" < m <= 100 000 " v"] | stem:[2000 " v" < m <= 10000 " v"] | stem:[200 " v" < m <= 1 000 " v"]
 |===
 
-The value of the apportioning factor, stem:[p_{"LC"}] shall appear on the OIML certificate,
-if the value is not equal to 0.7. If the apportioning factor, stem:[p_{"LC"}] is
+The value of the apportioning factor, stem:[p_("LC")] shall appear on the OIML certificate,
+if the value is not equal to 0.7. If the apportioning factor, stem:[p_("LC")] is
 not specified on the certificate then the value 0.7 shall be assumed. The maximum
 permissible error may be positive or negative and is applicable to both increasing
 and decreasing loads.
@@ -191,25 +191,25 @@ not be greater than the absolute value of the MPE for that load.
 [[sec-5.5.1]]
 ==== Creep
 
-The difference between the reading taken upon the application of a maximum load (stem:[D_{"max"}])
+The difference between the reading taken upon the application of a maximum load (stem:[D_("max")])
 and the reading observed within and after 30 minutes of exposure of 90 % to 100 %
-of stem:[E_{"max"}] shall not exceed 0.7 times the absolute value of MPE for the
+of stem:[E_("max")] shall not exceed 0.7 times the absolute value of MPE for the
 applied load.
 
 Regardless of any value declared by the manufacturer for the apportioning factor,
-stem:[p_{"LC"}], the MPE for creep shall be determined from stem:[table-4] using
-the apportioning factor, stem:[p_{"LC"} = 0.7].
+stem:[p_("LC")], the MPE for creep shall be determined from stem:[table-4] using
+the apportioning factor, stem:[p_("LC") = 0.7].
 
 The difference in readings taken after 20 minutes of exposure to 90 % to 100 % of
-stem:[E_{"max"}] and at 30 minutes of exposure to 90 % to 100 % of stem:[E_{"max"}]
+stem:[E_("max")] and at 30 minutes of exposure to 90 % to 100 % of stem:[E_("max")]
 shall not exceed 0.15 times the absolute value of MPE.
 
 ====
 Load cell class: C3 (declared by the manufacturer)
 
-Apportioning factor: stem:[p_{"LC"} = 0.7]
+Apportioning factor: stem:[p_("LC") = 0.7]
 
-Applied load: stem:[D_{"max"} = E_{"max"}] (test specification)
+Applied load: stem:[D_("max") = E_("max")] (test specification)
 
 Maximum difference between the reading stem:[= 0.7 xx (0.7 xx 1.5 v) = 0.735 v]
 ====
@@ -217,17 +217,17 @@ Maximum difference between the reading stem:[= 0.7 xx (0.7 xx 1.5 v) = 0.735 v]
 ====
 Load cell class: C3 (declared by the manufacturer)
 
-Apportioning factor: stem:[p_{"LC"} = 0.7]
+Apportioning factor: stem:[p_("LC") = 0.7]
 
-Applied load: stem:[D_{"max"} = E_{"max"}] (test specification)
+Applied load: stem:[D_("max") = E_("max")] (test specification)
 
 Maximum difference between the initial reading stem:[= 0.15 xx (0.7 xx 1.5 " v") = 0.1575 " v"]
 ====
 
 ==== Minimum dead load output return (DR) (see <<sec-3.5.10>>)
 
-The difference between the initial reading of the minimum load output (stem:[D_{"min"}])
-and the reading of stem:[D_{"min"}] at the conclusion of the creep test (<<sec-5.5.1>>),
+The difference between the initial reading of the minimum load output (stem:[D_("min")])
+and the reading of stem:[D_("min")] at the conclusion of the creep test (<<sec-5.5.1>>),
 shall not exceed half the value of the load cell verification interval
 (stem:[0.5 " v"]).
 
@@ -280,8 +280,8 @@ these ranges shall be at least:
 
 The minimum dead load output of the load cell over the temperature range, as specified
 in <<sec-5.6.1.1>> or <<sec-5.6.1.2>>, shall not vary by an amount greater than the
-apportioning factor, stem:[p_{"LC"}], times the minimum load cell verification interval,
-stem:[v_{"min"}], for any change in ambient temperature of:
+apportioning factor, stem:[p_("LC")], times the minimum load cell verification interval,
+stem:[v_("min")], for any change in ambient temperature of:
 
 [css text-indent:12.5mm]#stem:[2 "unitsml(degC)"] for load cells of class A;# +
 [css text-indent:12.5mm]#stem:[5 "unitsml(degC)"] for load cells of class B, C and D.#
@@ -289,7 +289,7 @@ stem:[v_{"min"}], for any change in ambient temperature of:
 ==== Barometric pressure
 
 The output of the load cell shall not vary by an amount greater than the minimum
-load cell verification interval, stem:[v_{"min"}], for any incremental change in
+load cell verification interval, stem:[v_("min")], for any incremental change in
 barometric pressure equivalent to stem:[1 "unitsml(kPa)"].
 
 [[sec-5.6.3]]
@@ -308,8 +308,8 @@ marking and not applicable to load cells marked NH or SH.
 
 The influence of exposure to temperature cycles specified in R 60-2, 2.10.5.12 <<R060-2,clause=2.10.5.12>> on
 the load cell output for minimum load shall not be greater than 4 % of the difference
-between the output on the maximum capacity, stem:[E_{"max"}], and that at the minimum
-dead load, stem:[E_{"min"}].
+between the output on the maximum capacity, stem:[E_("max")], and that at the minimum
+dead load, stem:[E_("min")].
 
 The influence of exposure to temperature cycles specified in R 60-2, 2.10.5.12 on
 the load cell output for the maximum load shall not be greater than the load cell
@@ -330,9 +330,9 @@ when exposed to conditions of relative humidity variations as specified in R 60-
 
 In addition to the other requirements of this Recommendation, analogue-active load
 cells shall comply with the following requirements. The MPE shall be determined using
-an apportioning factor, stem:[p_{"LC"}] greater than or equal to 0.7 and less than
-or equal to 0.8 (stem:[0.7 <= p_{"LC"} <= 0.8]) substituted for the apportioning
-factor, stem:[p_{"LC"}], that is declared by the manufacturer and applied to the
+an apportioning factor, stem:[p_("LC")] greater than or equal to 0.7 and less than
+or equal to 0.8 (stem:[0.7 <= p_("LC") <= 0.8]) substituted for the apportioning
+factor, stem:[p_("LC")], that is declared by the manufacturer and applied to the
 other requirements.
 
 If a digital load cell equipped with further data processing (<<sec-3.1.3.4>>) is
@@ -359,7 +359,7 @@ evaluated under the appropriate Recommendation for the complete instrument.
 Messages of significant faults should not be confused with other messages presented.
 
 NOTE: A fault in value that is equal to or smaller than the load cell minimum verification
-interval, stem:[v_{"min"}], is allowed.
+interval, stem:[v_("min")], is allowed.
 
 [[sec-5.7.1.2]]
 ===== Acting upon significant faults
@@ -421,8 +421,8 @@ the load cell output due to a disturbance and the load cell output without distu
 .Influence factors and disturbances
 [cols="<,^,^.^,^", options="header"]
 |===
-| Test | Subclause R 60-2, 2.10 test procedure | stem:[p_{"LC"}]
-footnote:[stem:[p_{"LC"} = 0.7] shall be used for analogue-active load cells during influence factors tests.]
+| Test | Subclause R 60-2, 2.10 test procedure | stem:[p_("LC")]
+footnote:[stem:[p_("LC") = 0.7] shall be used for analogue-active load cells during influence factors tests.]
 | Characteristic under test
 
 | Warm-up time | 2.10.7.3 .9+| 1.0 | Influence factor
@@ -441,4 +441,4 @@ footnote:[stem:[p_{"LC"} = 0.7] shall be used for analogue-active load cells dur
 When an analogue-active load cell is subjected to the span stability test specified
 in R 60-2, 2.10.7.11, the variation in the load cell span measurement results shall
 not exceed the greater of: half the load cell verification interval; or half the
-absolute value of the MPE for the applied test load stem:[D_{"max"}].
+absolute value of the MPE for the applied test load stem:[D_("max")].

--- a/sources/r060/1/sections/06-technical-requirements.adoc
+++ b/sources/r060/1/sections/06-technical-requirements.adoc
@@ -59,7 +59,7 @@ without damaging them.
 
 . Serial number
 
-. Maximum capacity as: stem:[E_{"max"} = "(in units g, kg, t)"]
+. Maximum capacity as: stem:[E_("max") = "(in units g, kg, t)"]
 
 . Year of production
 
@@ -93,16 +93,16 @@ with a specific unit of measure, the unit (g, kg, t) shall also be specified.
 
 . Humidity symbol when required; see <<sec-6.2.4.4>>
 
-. Maximum capacity as: stem:[E_{"max"} =]
+. Maximum capacity as: stem:[E_("max") =]
 
-. Minimum dead load as: stem:[E_{"min"} =]
+. Minimum dead load as: stem:[E_("min") =]
 
-. Safe load limit as: stem:[E_{"lim"} =]
+. Safe load limit as: stem:[E_("lim") =]
 
-. Minimum load cell verification interval as stem:[v_{"min"}] (or relative minimum
+. Minimum load cell verification interval as stem:[v_("min")] (or relative minimum
 load cell verification interval, stem:[Y]) =
 
-. Value of the apportioning factor, stem:[p_{"LC"}], if not equal to 0.7; and
+. Value of the apportioning factor, stem:[p_("LC")], if not equal to 0.7; and
 
 . Other pertinent conditions that must be observed to obtain the specified performance
 (for example, electrical characteristics of the load cell such as output rating,
@@ -114,12 +114,12 @@ In addition to the information required in <<sec-6.2.2>>, the following informat
 may optionally be specified:
 
 . for a weighing instrument (for example a multiple range instrument according to
-<<OIML_R_76_2006>>), the relative stem:[v_{"min"}], stem:[Y], where
-stem:[Y = (E_{"max"} - E_{"min"}) // v_{"min"}] (see <<sec-3.5.15>>);
+<<OIML_R_76_2006>>), the relative stem:[v_("min")], stem:[Y], where
+stem:[Y = (E_("max") - E_("min")) // v_("min")] (see <<sec-3.5.15>>);
 
 . for a weighing instrument (for example a multi-interval instrument according to
 <<OIML_R_76_76_2006>>), the relative DR, Z, where
-stem:[Z = (E_{"max"} - E_{"min"}) // (2 xx DR)] (see <<sec-3.5.14>>) and the value
+stem:[Z = (E_("max") - E_("min")) // (2 xx DR)] (see <<sec-3.5.14>>) and the value
 of DR (see <<sec-3.5.10>>) is set at the maximum permissible minimum dead load output
 return according to R 60-2, 2.10.1;
 

--- a/sources/r060/2/sections/02-type-evaluation.adoc
+++ b/sources/r060/2/sections/02-type-evaluation.adoc
@@ -262,10 +262,10 @@ during the entire period of the test.
 ===== Measuring range limits
 
 With consideration given to the capability of the force-generating system, the minimum
-load, stem:[D_{"min"}], shall be as near as possible to but not less than the minimum
-dead load, stem:[E_{"min"}], and shall not be higher than a value equal to 10 % of
-stem:[E_{"max"}]. The maximum load, stem:[D_{"max"}], shall be not less than 90 %
-of stem:[E_{"max"}], nor shall it be greater than stem:[E_{"max"}] (refer to R 60-1, Figure 3).
+load, stem:[D_("min")], shall be as near as possible to but not less than the minimum
+dead load, stem:[E_("min")], and shall not be higher than a value equal to 10 % of
+stem:[E_("max")]. The maximum load, stem:[D_("max")], shall be not less than 90 %
+of stem:[E_("max")], nor shall it be greater than stem:[E_("max")] (refer to R 60-1, Figure 3).
 
 ===== Reference standards
 
@@ -340,12 +340,12 @@ measuring ranges complying with the following conditions:
 
 [stem%unnumbered]
 ++++
-n <= n_{"LC"}
+n <= n_("LC")
 ++++
 
 [stem%unnumbered]
 ++++
-v => v_{"min"}
+v => v_("min")
 ++++
 
 [[sec-2.8.2]]
@@ -418,17 +418,17 @@ time (approximately 20 s) is increased to 25 s (125 % of 20 s), MPE is reduced t
 [[sec-2.9.1]]
 ==== Creep
 
-A load of stem:[D_{"max"}] shall be applied as specified in <<sec-2.10.2.1;to!sec-2.10.2.7>>,
+A load of stem:[D_("max")] shall be applied as specified in <<sec-2.10.2.1;to!sec-2.10.2.7>>,
 at which time an initial reading shall be taken. The variation between the initial
-reading and subsequent readings of the load stem:[D_{"max"}], taken as specified
+reading and subsequent readings of the load stem:[D_("max")], taken as specified
 in <<sec-2.10.2.8>>, shall comply with the limits specified in R 60-1, 5.5.1.
 
 [[sec-2.9.2]]
 ==== Minimum dead load output return
 
-The difference between an initial reading at a load of stem:[D_{"min"}] (as specified
-in <<sec-2.10.3.1;to!sec-2.10.3.6>>) and a subsequent reading also of stem:[D_{"min"}]
-(taken after the application of a load of stem:[D_{"max"}] as specified in <<sec-2.10.3.7;to!sec-2.10.3.10>>)
+The difference between an initial reading at a load of stem:[D_("min")] (as specified
+in <<sec-2.10.3.1;to!sec-2.10.3.6>>) and a subsequent reading also of stem:[D_("min")]
+(taken after the application of a load of stem:[D_("max")] as specified in <<sec-2.10.3.7;to!sec-2.10.3.10>>)
 shall not exceed the value in specified in R 60-1, 5.5.2.
 
 [[sec-2.10]]
@@ -456,13 +456,13 @@ has been given to those conditions, prior to performing the following tests.
 ===== Insert load cell
 
 Insert the load cell into the force-generating system, load to the minimum test load,
-stem:[D_{"min"}], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
+stem:[D_("min")], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
 
 [[sec-2.10.1.3]]
 ===== Preload load cell
 
-Preload the load cell by applying the maximum test load, stem:[D_{"max"}],
-three times, returning to the minimum test load, stem:[D_{"min"}], after each load
+Preload the load cell by applying the maximum test load, stem:[D_("max")],
+three times, returning to the minimum test load, stem:[D_("min")], after each load
 application. Wait 5 minutes before commencing with further tests.
 
 ===== Check indicating instrument
@@ -475,7 +475,7 @@ Monitor the minimum test load output until stable.
 
 ===== Record indication
 
-Record the indicating instrument indication at the minimum test load, stem:[D_{"min"}].
+Record the indicating instrument indication at the minimum test load, stem:[D_("min")].
 
 [[sec-2.10.1.7]]
 ===== Test load points
@@ -488,7 +488,7 @@ be recorded.
 [[sec-2.10.1.8]]
 ===== Apply loads
 
-Apply increasing loads up to the maximum test load, stem:[D_{"max"}]. There shall
+Apply increasing loads up to the maximum test load, stem:[D_("max")]. There shall
 be at least five increasing load points, which shall include values at or near those
 at which the maximum permissible error changes, as listed in Table 4 in R 60-1, 5.3.2.
 
@@ -500,7 +500,7 @@ be recorded.
 
 ===== Decrease test loads
 
-Decrease the test loads to the minimum test load, stem:[D_{"min"}], using the same
+Decrease the test loads to the minimum test load, stem:[D_("min")], using the same
 load points as described in <<sec-2.10.1.8>>.
 
 [[sec-2.10.1.11]]
@@ -554,12 +554,12 @@ has been given to those conditions prior to performing the following tests.
 ===== Insert load cell
 
 Insert the load cell into the force-generating system, load to the minimum test load,
-stem:[D_{"min"}], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
+stem:[D_("min")], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
 
 ===== Preload load cell
 
-Preload the load cell by applying the maximum test load, stem:[D_{"max"}], three
-times, returning to the minimum test load, stem:[D_{"min"}], after each load application.
+Preload the load cell by applying the maximum test load, stem:[D_("max")], three
+times, returning to the minimum test load, stem:[D_("min")], after each load application.
 Wait one hour.
 
 ===== Check indicating instrument
@@ -572,12 +572,12 @@ Monitor the minimum test load output until stable.
 
 ===== Record indication
 
-Record the indicating instrument indication at the minimum test load, stem:[D_{"min"}].
+Record the indicating instrument indication at the minimum test load, stem:[D_("min")].
 
 [[sec-2.10.2.7]]
 ===== Apply load
 
-Apply a constant maximum test load, stem:[D_{"max"}] (between 90 % and 100 % of stem:[E_{"max"}]).
+Apply a constant maximum test load, stem:[D_("max")] (between 90 % and 100 % of stem:[E_("max")]).
 
 [[sec-2.10.2.8]]
 ===== Record indications
@@ -611,13 +611,13 @@ has been given to those conditions prior to performing the following test.
 ===== Insert load cell
 
 Insert the load cell into the force-generating system, load to the minimum test load,
-stem:[D_{"min"}], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
+stem:[D_("min")], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
 
 [[sec-2.10.3.3]]
 ===== Preload load cell
 
-Preload the load cell by applying the maximum test load, stem:[D_{"max"}],
-three times, returning to the minimum test load, stem:[D_{"min"}], after each load
+Preload the load cell by applying the maximum test load, stem:[D_("max")],
+three times, returning to the minimum test load, stem:[D_("min")], after each load
 application. Wait one hour before commencing any further tests.
 
 ===== Check indicating instrument
@@ -631,12 +631,12 @@ Monitor the minimum test load output until stable.
 [[sec-2.10.3.6]]
 ===== Record indication
 
-Record the indicating instrument indication at the minimum test load, stem:[D_{"min"}].
+Record the indicating instrument indication at the minimum test load, stem:[D_("min")].
 
 [[sec-2.10.3.7]]
 ===== Apply load
 
-Apply a constant maximum test load, stem:[D_{"max"}] (between 90 % and 100 % of stem:[E_{"max"}]).
+Apply a constant maximum test load, stem:[D_("max")] (between 90 % and 100 % of stem:[E_("max")]).
 
 [[sec-2.10.3.10]]
 ===== Record indications
@@ -648,7 +648,7 @@ the load for a 30-minute period.
 
 ===== Record data
 
-Record the time of initiation of unloading and return to the minimum test load, stem:[D_{"min"}].
+Record the time of initiation of unloading and return to the minimum test load, stem:[D_("min")].
 
 ===== Record indication
 
@@ -715,12 +715,12 @@ has been given to those conditions prior to performing the following test.
 ===== Insert load cell
 
 Insert the load cell into the force-generating system, load to the minimum test load,
-stem:[D_{"min"}], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
+stem:[D_("min")], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
 
 ===== Preload load cell
 
-Preload the load cell by applying the maximum test load, stem:[D_{"max"}],
-three times, returning to the minimum test load, stem:[D_{"min"}], after each application.
+Preload the load cell by applying the maximum test load, stem:[D_("max")],
+three times, returning to the minimum test load, stem:[D_("min")], after each application.
 Wait 5 minutes before commencing any further tests.
 
 ===== Check indicating instrument
@@ -733,12 +733,12 @@ Monitor the minimum test load output until stable.
 
 ===== Record indication
 
-Record the indicating instrument indication at the minimum test load, stem:[D_{"min"}].
+Record the indicating instrument indication at the minimum test load, stem:[D_("min")].
 
 [[sec-2.10.5.7]]
 ===== Apply load
 
-Apply a maximum test load, stem:[D_{"max"}].
+Apply a maximum test load, stem:[D_("max")].
 
 ===== Record indications
 
@@ -748,7 +748,7 @@ shall be recorded.
 
 ===== Remove load
 
-Remove the test load to the minimum test load, stem:[D_{"min"}].
+Remove the test load to the minimum test load, stem:[D_("min")].
 
 [[sec-2.10.5.10]]
 ===== Record indication
@@ -826,8 +826,8 @@ to attain temperature stability (normally 1 to 2 hours).
 
 ===== Repeat test procedures
 
-Repeat <<sec-2.10.5.1;to!sec-2.10.5.11>> ensuring that the minimum test load, stem:[D_{"min"}],
-and the maximum test load, stem:[D_{"max"}], applied are the same as previously used.
+Repeat <<sec-2.10.5.1;to!sec-2.10.5.11>> ensuring that the minimum test load, stem:[D_("min")],
+and the maximum test load, stem:[D_("max")], applied are the same as previously used.
 
 [[sec-2.10.5.15]]
 ===== Determine the magnitude of humidity-induced variations
@@ -836,7 +836,7 @@ The difference between the average of the reading of the minimum load output and
 of the maximum output attributed to cyclic changes in humidity as determined using
 test procedures in <<sec-2.10.5>> shall not exceed the limits specified in R 60-1, 5.6.3.1.
 
-The difference between the average of the reading of the maximum load, stem:[D_{"max"}],
+The difference between the average of the reading of the maximum load, stem:[D_("max")],
 attributed to cyclic changes in humidity as determined using test procedures in <<sec-2.10.5>>
 shall not exceed the limits specified in R 60-1, 5.6.3.1.
 
@@ -854,12 +854,12 @@ has been given to those conditions prior to performing the following tests.
 ===== Insert load cell
 
 Insert the load cell into the force-generating system, load to the minimum test load,
-stem:[D_{"min"}], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
+stem:[D_("min")], and stabilise at stem:[20 "unitsml(degC)"] (stem:[pm 2 "unitsml(degC)"]).
 
 ===== Preload load cell
 
-Preload the load cell by applying the maximum test load, stem:[D_{"max"}],
-three times, returning to the minimum test load, stem:[D_{"min"}], after each load
+Preload the load cell by applying the maximum test load, stem:[D_("max")],
+three times, returning to the minimum test load, stem:[D_("min")], after each load
 application. Wait 5 minutes before commencing any further tests.
 
 ===== Check indicating instrument
@@ -872,7 +872,7 @@ Monitor the minimum test load output until stable.
 
 ===== Record indication
 
-Record the indicating instrument indication at the minimum test load, stem:[D_{"min"}].
+Record the indicating instrument indication at the minimum test load, stem:[D_("min")].
 
 ===== Test load points
 
@@ -884,7 +884,7 @@ be recorded.
 [[sec-2.10.6.8]]
 ===== Apply loads
 
-Apply increasing loads up to the maximum test load, stem:[D_{"max"_x}]. There shall
+Apply increasing loads up to the maximum test load, stem:[D_("max"_x)]. There shall
 be at least five increasing load points which shall include loads approximating to
 the highest values in the applicable steps of maximum permissible measurement errors,
 as listed in Table 4 in R 60-1, 5.3.2.
@@ -898,7 +898,7 @@ be recorded.
 [[sec-2.10.6.10]]
 ===== Decrease load
 
-Decrease the test load to the minimum test load, stem:[D_{"min"}], using the same
+Decrease the test load to the minimum test load, stem:[D_("min")], using the same
 load points as described in <<sec-2.10.6.8>>.
 
 ===== Conduct damp heat, steady state test
@@ -998,7 +998,7 @@ and the corrected error, stem:[E_c], prior to rounding is:
 E_C = E - E_0 <= MPE
 ++++
 
-where stem:[E_0] is the error calculated at the minimum test load, stem:[D_{"min"}].
+where stem:[E_0] is the error calculated at the minimum test load, stem:[D_("min")].
 
 ===== Warm-up time
 
@@ -1010,8 +1010,8 @@ to the test.
 
 Insert the load cell into the force-generating system.
 
-Preload the load cell by applying a maximum test load, stem:[D_{"max"}], then, returning
-to the minimum test load, stem:[D_{"min"}], three times.
+Preload the load cell by applying a maximum test load, stem:[D_("max")], then, returning
+to the minimum test load, stem:[D_("min")], three times.
 
 Allow the load cell to rest for 5 minutes. Connect the load cell to the power supply
 and switch on.
@@ -1019,13 +1019,13 @@ and switch on.
 Record data:
 
 As soon as a measurement result can be obtained, record the minimum test load output
-and the maximum test load, stem:[D_{"max"}], applied.
+and the maximum test load, stem:[D_("max")], applied.
 
 Loading and unloading:
 
 The maximum test load output shall be determined at time intervals as close as possible
 to those specified in <<table-1>> in <<sec-2.8.3>> and recorded and the load should
-be returned to the minimum test load, stem:[D_{"min"}]. These measurements shall
+be returned to the minimum test load, stem:[D_("min")]. These measurements shall
 be repeated after 5, 15 and 30 minutes.
 
 For load cells of class A, the provisions of the operating manual for the time following
@@ -1066,9 +1066,9 @@ Battery power voltage variations:
 - lower power voltage: (specified by the manufacturer, below stem:["unitsml(V)"])
 
 The voltage, (stem:["unitsml(V)"]) is the value specified by the manufacturer. If a
-range of reference mains power voltage (stem:[V_{"min"}, V_{"max"}]) is specified,
-then the test shall be performed at an upper voltage limit of stem:[V_{"max"}] and
-a lower voltage limit of stem:[V_{"min"}].
+range of reference mains power voltage (stem:[V_("min"), V_("max")]) is specified,
+then the test shall be performed at an upper voltage limit of stem:[V_("max")] and
+a lower voltage limit of stem:[V_("min")].
 
 | Test procedure in brief
 | This test consists of subjecting the load cell to variations of power voltage.
@@ -1456,10 +1456,10 @@ the total duration of the test.
 
 Test loads:
 
-A minimum test load, stem:[D_{"min"}]; the same test load shall be used throughout
+A minimum test load, stem:[D_("min")]; the same test load shall be used throughout
 the test.
 
-A maximum test load, stem:[D_{"max"}]; the same test load shall be used throughout
+A maximum test load, stem:[D_("max")]; the same test load shall be used throughout
 the test.
 
 Number of measurements: At least 8.
@@ -1472,15 +1472,15 @@ Stabilise all factors at sufficiently constant ambient conditions.
 
 Each set of measurements shall consist of the following:
 
-. preload the load cell by applying the maximum test load, stem:[D_{"max"}],
-three times, returning to the minimum test load, stem:[D_{"min"}], after each load
+. preload the load cell by applying the maximum test load, stem:[D_("max")],
+three times, returning to the minimum test load, stem:[D_("min")], after each load
 application;
 
-. stabilise the load cell at the minimum test load, stem:[D_{"min"}];
+. stabilise the load cell at the minimum test load, stem:[D_("min")];
 
-. read the minimum test load output and apply the maximum test load, stem:[D_{"max"}].
+. read the minimum test load output and apply the maximum test load, stem:[D_("max")].
 Read the maximum test load output at time intervals as near as possible to those
-specified in <<table-1>> in <<sec-2.8.3>>, and return to the minimum test load, stem:[D_{"min"}].
+specified in <<table-1>> in <<sec-2.8.3>>, and return to the minimum test load, stem:[D_("min")].
 Repeat this four more times for accuracy class B or two more times for accuracy classes
 C and D;
 

--- a/sources/r060/3/sections/02-applicability.adoc
+++ b/sources/r060/3/sections/02-applicability.adoc
@@ -49,8 +49,8 @@ the increasing load tests at the initial stem:[20 "unitsml(degC)"] nominal test 
 ===== {blank}
 
 If a test load corresponding to 75 % of the measuring range for the load cell under
-test (i.e. stem:[2250] divisions for a stem:[3000] division cell, which is stem:[D_{"min"}]
-plus 75 % of the difference between stem:[D_{"max"}] and stem:[D_{"min"}]) is not
+test (i.e. stem:[2250] divisions for a stem:[3000] division cell, which is stem:[D_("min")]
+plus 75 % of the difference between stem:[D_("max")] and stem:[D_("min")]) is not
 included in the test loads used in <<table-6.3>>, interpolate between the adjacent
 upper and lower values of the averages of all three test runs and record in <<table-6.5>>
 (see R 60-2, 2.8.2).
@@ -59,15 +59,15 @@ upper and lower values of the averages of all three test runs and record in <<ta
 ===== {blank}
 
 Calculate the difference between the average indication on the increasing load test
-runs at 75 % of the difference between stem:[D_{"max"}] and stem:[D_{"min"}] and
-the indication at stem:[D_{"min"}]. Divide the result (to five significant figures)
+runs at 75 % of the difference between stem:[D_("max")] and stem:[D_("min")] and
+the indication at stem:[D_("min")]. Divide the result (to five significant figures)
 by the number of verification intervals (75 % of stem:[n]) for that load to obtain
 the conversion factor, stem:[f], and record in the tables that follow.
 
 [stem%unnumbered]
 ++++
-f = {"average indication at" quad 0.75 cdot (D_{"max"} - D_{"min"}) -
-"indication at" quad D_{"min"}} / {0.75 cdot n}
+f = {"average indication at" quad 0.75 cdot (D_("max") - D_("min")) -
+"indication at" quad D_("min")} / {0.75 cdot n}
 ++++
 
 The units of conversion factor, stem:[f], are indicated units (e.g. digits or counts)
@@ -77,29 +77,29 @@ per load cell verification interval, stem:[v].
 
 Enter the average test indications of the tests at the temperatures following the
 initial test at a nominal stem:[20 "unitsml(degC)"] in <<table-6.5>>. In recording
-this data, indicate a "no test load" indication (at stem:[D_{"min"}]) as "0".
-This may require subtracting the "no load indication at stem:[D_{"min"}]" from the
+this data, indicate a "no test load" indication (at stem:[D_("min")]) as "0".
+This may require subtracting the "no load indication at stem:[D_("min")]" from the
 "test load indication" so that the first entry in the column is "0". These "0's"
 have been preprinted on the form to clarify that a dead load condition is recorded
 as "0".
 
 ===== {blank}
 
-Calculate the reference indication, stem:[R_{"i"}], by converting the net test load,
+Calculate the reference indication, stem:[R_("i")], by converting the net test load,
 in mass units, to indicated units (e.g. counts or digits), by multiplying by the
 conversion factor, stem:[f], for each test load and recording in the 2nd column in
 <<table-6.5>>.
 
 [stem%unnumbered]
 ++++
-R_i = {("test load" quad i - D_{"min"})} / {(D_{"max"} - D_{"min"})} cdot n cdot f
+R_i = {("test load" quad i - D_("min"))} / {(D_("max") - D_("min"))} cdot n cdot f
 ++++
 
 ===== {blank}
 
 In <<table-6.5>> calculate the difference between the average test indication and
 the reference indication for each test load at each test temperature and divide the
-result by the conversion factor, stem:[f], to obtain the error, stem:[E_{"L"}], for
+result by the conversion factor, stem:[f], to obtain the error, stem:[E_("L")], for
 each test load in terms of stem:[v].
 
 [stem%unnumbered]
@@ -109,7 +109,7 @@ E_L = ("average test indication for test load" quad i - "reference indication" q
 
 ===== {blank}
 
-Compare stem:[E_{"L"}] with the corresponding MPE for each test load.
+Compare stem:[E_("L")] with the corresponding MPE for each test load.
 
 ==== Repeatability error (stem:[E_R] in terms of verification interval, stem:[v])
 
@@ -120,7 +120,7 @@ Enter data in <<table-6.6>>.
 ===== {blank}
 
 Calculate the maximum difference between the test indications on <<form-6.3,Form 6.3>>
-and divide it by stem:[f] to obtain the repeatability error, stem:[E_{"R"}], in terms
+and divide it by stem:[f] to obtain the repeatability error, stem:[E_("R")], in terms
 of the load cell verification interval, stem:[v].
 
 [stem%unnumbered]
@@ -130,7 +130,7 @@ E_R = ("maximum indication of the test load" - "minimum indication") // f
 
 ===== {blank}
 
-Compare stem:[E_{"R"}] with the absolute value of the corresponding MPE for each
+Compare stem:[E_("R")] with the absolute value of the corresponding MPE for each
 test load.
 
 ==== Temperature effects on minimum dead load output (MDLO) (stem:[C_M =] Change MDLO)
@@ -138,46 +138,46 @@ test load.
 ===== {blank}
 
 Enter in <<table-6.7>> the average indication for the initial minimum test load,
-stem:[D_{"min"}], for each test temperature from <<table-6.3>>.
+stem:[D_("min")], for each test temperature from <<table-6.3>>.
 
 ===== {blank}
 
 Calculate the difference between the average test indications for each temperature
-stem:[T_{"i"}] in sequence and divide the result by the conversion factor, stem:[f],
+stem:[T_("i")] in sequence and divide the result by the conversion factor, stem:[f],
 to obtain the change in terms of the load cell verification interval, stem:[v].
 
 [stem%unnumbered]
 ++++
-C_{"M"} = ("average test indication at" quad T_2 - "average indication at" quad T_1) // f
+C_("M") = ("average test indication at" quad T_2 - "average indication at" quad T_1) // f
 ++++
 
 ===== {blank}
 
-Divide stem:[C_{"M"}] by (stem:[T_2 - T_1]) and multiply the result by a factor
-stem:[T_{"f"} = 5] for class B, C, and D load cells or stem:[T_{"f"} = 2] for class
+Divide stem:[C_("M")] by (stem:[T_2 - T_1]) and multiply the result by a factor
+stem:[T_("f") = 5] for class B, C, and D load cells or stem:[T_("f") = 2] for class
 A load cells. This gives the change in stem:[v] per stem:[5 "unitsml(degC)"] for
 class B, C, and D load cells or in stem:[v] per stem:[2 "unitsml(degC)"] for class
 A load cells.
 
 ===== {blank}
 
-Multiply the result by stem:[[(D_{"max"} - D_{"min"}) // n // v_{"min"}]] to give
-the final result stem:[C_{"M"}( v_{"min"})] in units of stem:[v_{"min"}] per
-stem:[5 "unitsml(degC)"] for class B, C, and D load cells, or in units of stem:[v_{"min"}]
-per stem:[2 "unitsml(degC)"] for class A load cells. stem:[C_{"M"}(v_{"min"})] must
-not exceed stem:[p_{"LC"}].
+Multiply the result by stem:[[(D_("max") - D_("min")) // n // v_("min")]] to give
+the final result stem:[C_("M")( v_("min"))] in units of stem:[v_("min")] per
+stem:[5 "unitsml(degC)"] for class B, C, and D load cells, or in units of stem:[v_("min")]
+per stem:[2 "unitsml(degC)"] for class A load cells. stem:[C_("M")(v_("min"))] must
+not exceed stem:[p_("LC")].
 
 [stem%unnumbered]
 ++++
-bb(C_M(v_{"min"}) = | {C_M cdot T_f}/{(T_2 - T_1)} xx {(D_{"max"} - D_{"min"})} / {n cdot v_{"min"}} |)
+bb(C_M(v_("min")) = | {C_M cdot T_f}/{(T_2 - T_1)} xx {(D_("max") - D_("min"))} / {n cdot v_("min")} |)
 ++++
 
 [stem%unnumbered]
 ++++
-C_M(v_{"min"}) <= p_{LC}
+C_M(v_("min")) <= p_(LC)
 ++++
 
-==== Creep magnitude stem:[C_C(t)] and minimum dead load output return (stem:[C_{"DR"}])
+==== Creep magnitude stem:[C_C(t)] and minimum dead load output return (stem:[C_("DR")])
 
 (stem:[C_C(t) =] Creep, expressed in terms of the load cell verification interval, stem:[v])
 
@@ -190,7 +190,7 @@ interval, stem:[v].
 From the test indications recorded in <<table-6.8>>, calculate the difference between
 the initial indication obtained at the minimum creep test load after the stabilisation
 period and any indication obtained over the 30 minute test period with the maximum
-creep test load of 90 % to 100 % of stem:[E_{"max"}] and divide by the conversion
+creep test load of 90 % to 100 % of stem:[E_("max")] and divide by the conversion
 factor, stem:[f].
 
 [stem%unnumbered]
@@ -199,25 +199,25 @@ C_C (t) = ("indication" - "initial indication") // f
 ++++
 
 Remark: If the minimum creep test load or the maximum creep test load differ from
-stem:[D_{"min"}] or stem:[D_{"max"}] according to <<sec-2.1.2>> "Load cell errors
-stem:[E_{"L"}]" the conversion factor, stem:[f], must be recalculated with the minimum
+stem:[D_("min")] or stem:[D_("max")] according to <<sec-2.1.2>> "Load cell errors
+stem:[E_("L")]" the conversion factor, stem:[f], must be recalculated with the minimum
 and maximum creep test loads (see <<sec-2.1.2.4>>).
 
 ===== {blank}
 
-stem:[C_{"C"}(t)] must not exceed 0.7 times the absolute value of the MPE for the
+stem:[C_("C")(t)] must not exceed 0.7 times the absolute value of the MPE for the
 maximum creep test load at any time stem:[t] over the 30 minute creep test period.
 
 ===== {blank}
 
 Calculate the difference between the test indications obtained at stem:[t = 20] minutes
 and stem:[t = 30] minutes after the initial indication at stem:[t = t_0] and divide
-by stem:[f] to obtain the creep error, stem:[C_{"C"} (30 - 20)], in terms of the
+by stem:[f] to obtain the creep error, stem:[C_("C") (30 - 20)], in terms of the
 load cell verification interval, stem:[v].
 
 [stem%unnumbered]
 ++++
-C_{"C"} (30 - 20) = ("indication at time" quad t = 30 quad "minutes" - "indication at time" quad t = 20 quad "minutes") // f
+C_("C") (30 - 20) = ("indication at time" quad t = 30 quad "minutes" - "indication at time" quad t = 20 quad "minutes") // f
 ++++
 
 ===== {blank}
@@ -231,17 +231,17 @@ Calculate the difference between the initial indication obtained at the minimum 
 test load after the stabilisation period (stem:[t_0 = 0 "unitsml(min)"]) and the
 indication at the minimum creep test load after the creep test and after a time interval
 for stabilisation (stem:[t > 30 "unitsml(min)"]) and divide the result by conversion
-factor, stem:[f], to obtain the minimum dead load output return, stem:[C_{"DR"}],
+factor, stem:[f], to obtain the minimum dead load output return, stem:[C_("DR")],
 in terms of stem:[v].
 
 [stem%unnumbered]
 ++++
-C_{"DR"} = ("minimum test load indication"2 - "minimum test load indication"1) // f
+C_("DR") = ("minimum test load indication"2 - "minimum test load indication"1) // f
 ++++
 
 ===== {blank}
 
-If the time intervals specified in R 60-2, Table 1 have been met, stem:[C_{"DR"}]
+If the time intervals specified in R 60-2, Table 1 have been met, stem:[C_("DR")]
 must not exceed 0.5 stem:[v].
 
 ===== {blank}
@@ -251,7 +251,7 @@ R 60-2, Table 1, then the following applies:
 
 [stem%unnumbered]
 ++++
-C_{"DR"} <=  0.5 (1 - (x - 1)) v
+C_("DR") <=  0.5 (1 - (x - 1)) v
 ++++
 
 [align=center]
@@ -262,7 +262,7 @@ stem:[x =] actual time/specified time
 
 ===== {blank}
 
-Whereas stem:[C_{"DR"}] expresses the minimum dead load output return in terms of
+Whereas stem:[C_("DR")] expresses the minimum dead load output return in terms of
 stem:[v], the value of stem:[DR] as used in <<OIML_R_76_2006>> is expressed in units of
 mass (stem:["unitsml(g)"], stem:["unitsml(kg)"] or stem:["unitsml(t)"]).
 
@@ -270,13 +270,13 @@ mass (stem:["unitsml(g)"], stem:["unitsml(kg)"] or stem:["unitsml(t)"]).
 
 Calculate the minimum dead load output return, stem:[DR], expressed in units of mass
 (stem:["unitsml(g)"], stem:["unitsml(kg)"] or stem:["unitsml(t)"]) as follows:
-stem:[DR_ = (E_{"max"} - E_{"min"}) C_{"DR"} // n_{"LC"}]
+stem:[DR_ = (E_("max") - E_("min")) C_("DR") // n_("LC")]
 
 ===== {blank}
 
 Regardless of the value declared by the manufacturer for the apportionment factor,
-stem:[p_{"LC"}], the MPE for creep shall be determined from R 60-1, Table 4 using
-the apportionment factor, stem:[p_{"LC"} = 0.7] (see R 60-1, 5.5.1).
+stem:[p_("LC")], the MPE for creep shall be determined from R 60-1, Table 4 using
+the apportionment factor, stem:[p_("LC") = 0.7] (see R 60-1, 5.5.1).
 
 ==== Barometric pressure effects footnote:[This test may not be necessary depending on the design of the load cell.] (stem:[C_P =] Change due to barometric pressure)
 
@@ -284,7 +284,7 @@ the apportionment factor, stem:[p_{"LC"} = 0.7] (see R 60-1, 5.5.1).
 
 From the test indications recorded in R 60-3, <<table-6.9>>, calculate the difference
 between the indications for each pressure and divide the result by conversion factor,
-stem:[f], to obtain the change, stem:[C_{"P"}], in terms of stem:[v].
+stem:[f], to obtain the change, stem:[C_("P")], in terms of stem:[v].
 
 [stem%unnumbered]
 ++++
@@ -293,70 +293,70 @@ C_P = ("indication at " P_2 - "indication at " P_1) // f
 
 ===== {blank}
 
-Divide stem:[C_{"P"}] by (stem:[P_2 - P_1]) to determine the change due to barometric
+Divide stem:[C_("P")] by (stem:[P_2 - P_1]) to determine the change due to barometric
 pressure in terms of stem:[v] per kilopascal (stem:["unitsml(kPa)"]).
 
 ===== {blank}
 
-Multiply the result by [stem:[(E_{"max"} - E_{"min"}) // n_{"LC"}] to obtain the
+Multiply the result by [stem:[(E_("max") - E_("min")) // n_("LC")] to obtain the
 result in units of mass (g, kg, or t) per stem:["unitsml(kPa)"] (as stated by the
-manufacturer). The result must not exceed stem:[v_{"min"}].
+manufacturer). The result must not exceed stem:[v_("min")].
 
 [stem%unnumbered]
 ++++
-C_P(v) = C_P/{(P_2 - P_1)} cdot {(E_{"max"} - E_{"min"})}/n_{"max"} <= v_min
+C_P(v) = C_P/{(P_2 - P_1)} cdot {(E_("max") - E_("min"))}/n_("max") <= v_min
 ++++
 
 ==== Humidity effects footnote:[This test is not necessary if the load cell is marked NH or SH.] (CH or no mark)
 
-(stem:[C_{"Hmin"} =] Change in terms of stem:[v] due to Humidity effect on the indication
-of the minimum test load stem:[D_{"min"}])
+(stem:[C_("Hmin") =] Change in terms of stem:[v] due to Humidity effect on the indication
+of the minimum test load stem:[D_("min")])
 
-(stem:[C_{"Hmax"} =] Change due to Humidity effect on the indication of the maximum
-test load stem:[D_{"max"}])
+(stem:[C_("Hmax") =] Change due to Humidity effect on the indication of the maximum
+test load stem:[D_("max")])
 
 Remark: If the minimum or maximum test load used for this test differ from the minimum
-test load stem:[D_{"min"}] or maximum test load stem:[D_{"max"}] according to
-R 60-3, 2.1.2 "Load cell errors stem:[E_{"L"}]" the conversion factor, stem:[f],
+test load stem:[D_("min")] or maximum test load stem:[D_("max")] according to
+R 60-3, 2.1.2 "Load cell errors stem:[E_("L")]" the conversion factor, stem:[f],
 must be recalculated with the minimum and maximum test loads of this test
 (see R 60-3, 2.1.2.4).
 
 ===== {blank}
 
 From the test indications recorded in R 60-3, Table 6.10.1, calculate the difference
-between the initial indications for the minimum test load, stem:[D_{"min"}], before
+between the initial indications for the minimum test load, stem:[D_("min")], before
 and after the damp heat test and divide the result by conversion factor, stem:[f],
-to obtain the change, stem:[C_{"Hmin"}], in terms of verification interval, stem:[v]
+to obtain the change, stem:[C_("Hmin")], in terms of verification interval, stem:[v]
 (see R 60-1, 5.6.3.1).
 
 [stem%unnumbered]
 ++++
-C_{"Hmin"} = [("indication at " D_{"min"})_{"after"} - ("indication at " D_{"min"} )_{"before"}] // f
+C_("Hmin") = [("indication at " D_("min"))_("after") - ("indication at " D_("min") )_("before")] // f
 ++++
 
 [stem%unnumbered]
 ++++
-C_{"Hmin"} " must not exceed 0.04 " cdot n.
+C_("Hmin") " must not exceed 0.04 " cdot n.
 ++++
 
 ===== {blank}
 
-Calculate the average indications stem:[bar I{D_{"max"}}] and stem:[bar I{D_{"min"}]
-at stem:[D_{"min"}] (see R 60-2, 2.10.5) for the required number of test indications,
-before and after the damp heat test. Subtract stem:[bar I{D_{"min"] from
-stem:[bar I{D_{"max"}}] for the tests before and after damp heat test and then calculate
+Calculate the average indications stem:[bar I(D_("max"))] and stem:[bar I(D_("min"))]
+at stem:[D_("min")] (see R 60-2, 2.10.5) for the required number of test indications,
+before and after the damp heat test. Subtract stem:[bar I(D_("min"))] from
+stem:[bar I(D_("max"))] for the tests before and after damp heat test and then calculate
 the difference between the results. Divide the result by the conversion factor, stem:[f],
-to obtain the change, stem:[C_{"Hmax"}] in terms of stem:[v].
+to obtain the change, stem:[C_("Hmax")] in terms of stem:[v].
 
 [stem%unnumbered]
 ++++
-C_{"Hmax"} = {[(bar I{D_{"max"}} - bar I{D_{"min"}})_{"after"} - (bar I{D_{"max"}} -
-bar I{D_{"min"}})_{"before"}]} / f
+C_("Hmax") = ([(bar I(D_("max")) - bar I(D_("min")))_("after") - (bar I(D_("max")) -
+bar I(D_("min")))_("before")]) / f
 ++++
 
 ===== {blank}
 
-stem:[C_{"Hmax"}] must not exceed the MPE (see R 60-1, Table 4 in 5.3.2).
+stem:[C_("Hmax")] must not exceed the MPE (see R 60-1, Table 4 in 5.3.2).
 
 ==== Humidity effects footnote:[This test is not necessary if the load cell is marked NH or CH or has no humidity marking.] (SH)
 
@@ -376,8 +376,8 @@ Enter data on R 60-3, Form 6.11 (Warm-up time).
 
 ===== {blank}
 
-Span is the result of subtraction of the indication at the minimum test load, stem:[D_{"min"}],
-from the indication at the maximum test load, stem:[D_{"max"}].
+Span is the result of subtraction of the indication at the minimum test load, stem:[D_("min")],
+from the indication at the maximum test load, stem:[D_("max")].
 
 ===== {blank}
 
@@ -558,33 +558,33 @@ image::figure-1.png[]
 
 | stem:[C_C(30 - 20)] | difference between output at stem:[t = 30] minutes and at stem:[t = 20] minutes during creep test. | 2.1.5.2
 
-| stem:[C_{"DR"}] | minimum dead load output return, expressed in terms of stem:[v] | 2.1.5
+| stem:[C_("DR")] | minimum dead load output return, expressed in terms of stem:[v] | 2.1.5
 
-| stem:[C_{"Hmax"}] | humidity effect on maximum test load output, expressed in terms of stem:[v] | 2.1.7
+| stem:[C_("Hmax")] | humidity effect on maximum test load output, expressed in terms of stem:[v] | 2.1.7
 
-| stem:[C_{"Hmin"}] | humidity effect on minimum test load output, expressed in terms of stem:[v] | 2.1.7
+| stem:[C_("Hmin")] | humidity effect on minimum test load output, expressed in terms of stem:[v] | 2.1.7
 
-| stem:[C_{"M"}] | temperature effect on minimum dead load output, expressed in terms of stem:[v]. | 2.1.4
+| stem:[C_("M")] | temperature effect on minimum dead load output, expressed in terms of stem:[v]. | 2.1.4
 
-| stem:[C_{"M"}(v_{"min"})] | temperature effect on minimum dead load output, expressed in terms of  stem:[v_{"min"}] per stem:[5 "unitsml(degC)"] for class B, C and D or per stem:[2 "unitsml(degC)"] for class A. | 2.1.4
+| stem:[C_("M")(v_("min"))] | temperature effect on minimum dead load output, expressed in terms of  stem:[v_("min")] per stem:[5 "unitsml(degC)"] for class B, C and D or per stem:[2 "unitsml(degC)"] for class A. | 2.1.4
 
-| stem:[C_{"P"}] | barometric pressure effect, expressed in terms of stem:[v] | 2.1.6
+| stem:[C_("P")] | barometric pressure effect, expressed in terms of stem:[v] | 2.1.6
 
-| stem:[C_{"P"}(v_{"min"})] | barometric pressure effect, expressed in terms of mass (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) per stem:["unitsml(kPa)"]. | 2.1.6
+| stem:[C_("P")(v_("min"))] | barometric pressure effect, expressed in terms of mass (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) per stem:["unitsml(kPa)"]. | 2.1.6
 
-| stem:[D_{"max"}] | maximum test load | R 60-1, 3.5.6
+| stem:[D_("max")] | maximum test load | R 60-1, 3.5.6
 
-| stem:[D_{"min"}] | minimum test load | R 60-1, 3.5.12
+| stem:[D_("min")] | minimum test load | R 60-1, 3.5.12
 
 | stem:[DR] | minimum dead load output return, expressed in mass units (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) | R 60-1, 3.5.10
 
-| stem:[E_{"L"}] | load cell error, expressed in terms of stem:[v] | 2.1.2
+| stem:[E_("L")] | load cell error, expressed in terms of stem:[v] | 2.1.2
 
-| stem:[E_{"max"}] | maximum capacity of the load cell | R 60-1, 3.5.5
+| stem:[E_("max")] | maximum capacity of the load cell | R 60-1, 3.5.5
 
-| stem:[E_{"min"}] | minimum dead load of the load cell | R 60-1, 3.5.9
+| stem:[E_("min")] | minimum dead load of the load cell | R 60-1, 3.5.9
 
-| stem:[E_{"R"}] | repeatability error, expressed in terms of stem:[v] | 2.1.3
+| stem:[E_("R")] | repeatability error, expressed in terms of stem:[v] | 2.1.3
 
 | stem:[f] | conversion factor, number of indicated units per verification interval, stem:[v] | 2.1.2.4
 
@@ -592,11 +592,11 @@ image::figure-1.png[]
 
 | stem:[n] | number of load cell verification intervals into which the load cell measuring range is divided | R 60-1 3.5.13
 
-| stem:[n_{"LC"}] | maximum number of load cell verification intervals | R 60-1, 3.5.8
+| stem:[n_("LC")] | maximum number of load cell verification intervals | R 60-1, 3.5.8
 
-| stem:[p_{"LC"}] | apportionment factor | R 60-1, 3.7.2
+| stem:[p_("LC")] | apportionment factor | R 60-1, 3.7.2
 
-| stem:[R_{"i"}] | reference indication (net test load), expressed in indication units | 2.1.2.6
+| stem:[R_("i")] | reference indication (net test load), expressed in indication units | 2.1.2.6
 
 | stem:[t_0] | time stem:[t_0 = 0 "unitsml(min)"] when the initial indication at minimum test load is measured | 2.1.5
 
@@ -606,11 +606,11 @@ image::figure-1.png[]
 
 | stem:[v] | load cell verification interval | R 60-1, 3.5.4
 
-| stem:[v_{"min"}] | minimum load cell verification interval | R 60-1, 3.5.11
+| stem:[v_("min")] | minimum load cell verification interval | R 60-1, 3.5.11
 
-| stem:[Y] | relative stem:[v_{"min"}], stem:[Y = (E_{"max"} - E_{"min"}) // v_{"min"}] | R 60-1, 3.5.15,
+| stem:[Y] | relative stem:[v_("min")], stem:[Y = (E_("max") - E_("min")) // v_("min")] | R 60-1, 3.5.15,
 
-| stem:[Z] | relative DR, stem:[Z = (E_{"max"} - E_{"min"}) // (2 xx DR)] | R 60-1, 3.5.14
+| stem:[Z] | relative DR, stem:[Z = (E_("max") - E_("min")) // (2 xx DR)] | R 60-1, 3.5.14
 |===
 
 === Summary of formulae contained within calculation procedures
@@ -619,42 +619,42 @@ image::figure-1.png[]
 |===
 | Symbol | Formula 
 
-| stem:[C_{"C"}] | stem:[C_C = ("indication" - "initial indication") // f]
+| stem:[C_("C")] | stem:[C_C = ("indication" - "initial indication") // f]
 
-| stem:[C_{"C"}(30 - 20)]
-| stem:[C_{"C"}(30 - 20) = ("test indication at 30 minutes" - "test indication at 20 minutes") // f]
+| stem:[C_("C")(30 - 20)]
+| stem:[C_("C")(30 - 20) = ("test indication at 30 minutes" - "test indication at 20 minutes") // f]
 
-| stem:[C_{"DR"}]
-| stem:[C_{"DR"} = ("minimum test load indication2" - "minimum test load indication1") // f]
+| stem:[C_("DR")]
+| stem:[C_("DR") = ("minimum test load indication2" - "minimum test load indication1") // f]
 
-| stem:[C_{"Hmin"}]
-| stem:[C_{"Hmin"} = [("indication at" quad D_{"min"})_{"after"} - ("indication at" quad D_{"min"})_{"before"}] // f]
+| stem:[C_("Hmin")]
+| stem:[C_("Hmin") = [("indication at" quad D_("min"))_("after") - ("indication at" quad D_("min"))_("before")] // f]
 
-| stem:[C_{"Hmax"}]
-| stem:[C_{"Hmax"} = [("indication at" quad D_{"max"} - "indication at" quad D_{"min"})_{"after"} - ("indication at" quad D_{"max"} - "indication"]
+| stem:[C_("Hmax")]
+| stem:[C_("Hmax") = [("indication at" quad D_("max") - "indication at" quad D_("min"))_("after") - ("indication at" quad D_("max") - "indication"]
 
-| stem:[C_{"M"}]
-| stem:[C_{"M"} = ("average test indication at" quad T_2 - "average indication at" quad T_1) // f]
+| stem:[C_("M")]
+| stem:[C_("M") = ("average test indication at" quad T_2 - "average indication at" quad T_1) // f]
 
-| stem:[C_{"P"}]
-| stem:[C_{"P"} = ("indication at" quad P_2 - "indication at" quad P_1) // f]
+| stem:[C_("P")]
+| stem:[C_("P") = ("indication at" quad P_2 - "indication at" quad P_1) // f]
 
 | DR
-| stem:[DR = (E_{"max"} - E_{"min"}) xx C_{"DR"} // n_{"LC"}]
+| stem:[DR = (E_("max") - E_("min")) xx C_("DR") // n_("LC")]
 
-| stem:[E_{"L"}]
-| stem:[E_{"L"} = ("average test indication" - "reference indication") // f]
+| stem:[E_("L")]
+| stem:[E_("L") = ("average test indication" - "reference indication") // f]
 
-| stem:[E_{"R"}]
-| stem:[E_{"R"} = ("maximum indication" - "minimum indication") // f]
+| stem:[E_("R")]
+| stem:[E_("R") = ("maximum indication" - "minimum indication") // f]
 
 | stem:[f]
-| stem:[f = "average indication at " 0.75 cdot (D_{"max"} - D_{"min"}) - "indication at " D_{"min"} // 0.75 cdot n]
+| stem:[f = "average indication at " 0.75 cdot (D_("max") - D_("min")) - "indication at " D_("min") // 0.75 cdot n]
 
 ++[++see <<note-2.5-2>>]
 
-| stem:[R_{"i"}]
-| stem:[R_{"i"} = [("test load" - D_{"min"}) // (D_{"max"} - D_{"min"})\] xx n xx f]
+| stem:[R_("i")]
+| stem:[R_("i") = [("test load" - D_("min")) // (D_("max") - D_("min"))\] xx n xx f]
 |===
 
 NOTE: Observe extreme caution by referring to calculation procedure for correct application

--- a/sources/r060/3/sections/04-evaluation-report.adoc
+++ b/sources/r060/3/sections/04-evaluation-report.adoc
@@ -168,11 +168,11 @@ _(as provided by the manufacturer prior to the evaluation)_
 | | Unit | Range
 
 | Accuracy classes | |
-| Maximum number of verification intervals, stem:[n_{"LC"}] | |
-| Maximum capacity, stem:[E_{"max"}] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
-| Minimum capacity, stem:[E_{"min"}] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
-| Minimum load cell verification interval, stem:[v_{"min"} = (E_{"max"} - E_{"min"}) // Y] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
-| Minimum dead load output return, stem:[DR = 1//2 (E_{"max"} - E_{"min"})//Z] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Maximum number of verification intervals, stem:[n_("LC")] | |
+| Maximum capacity, stem:[E_("max")] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Minimum capacity, stem:[E_("min")] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Minimum load cell verification interval, stem:[v_("min") = (E_("max") - E_("min")) // Y] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Minimum dead load output return, stem:[DR = 1//2 (E_("max") - E_("min"))//Z] | (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
 | Rated output | (stem:["unitsml(mV/V)"] or counts) |
 | Input impedance | stem:["unitsml(Ohm)"] |
 |===
@@ -220,10 +220,10 @@ This test report is issued for the following load cell:
 |===
 .2+h| Model designation .2+h| Serial number h| Maximum capacity h| Maximum number of load cell intervals h| Minimum load cell verification interval h| Minimum dead load output return
 
-| stem:[E_{"max"}] +
+| stem:[E_("max")] +
 (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])
-| stem:[n_{"LC"}]
-| stem:[v_{"min"}] +
+| stem:[n_("LC")]
+| stem:[v_("min")] +
 (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])
 | DR (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])
 
@@ -295,11 +295,11 @@ Further information concerning adjustments:
 | Sealing of strain gauge application (e.g. hermetically, potted) 2+|
 | Digital load cell (Yes / no) 2+|
 | Accuracy classes 2+|
-| Maximum number of verification intervals, stem:[n_{"LC"}] 2+|
-| Maximum capacity, stem:[E_{"max"}] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
-| Minimum capacity, stem:[E_{"min"}] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
-| Minimum load cell verification interval, stem:[v_{"min"} = (E_{"max"} - E_{"min"}) // Y] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
-| Minimum dead load output return, stem:["DR" = 1/2 (E_{"max"} - E_{"min"})//Z] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Maximum number of verification intervals, stem:[n_("LC")] 2+|
+| Maximum capacity, stem:[E_("max")] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Minimum capacity, stem:[E_("min")] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Minimum load cell verification interval, stem:[v_("min") = (E_("max") - E_("min")) // Y] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
+| Minimum dead load output return, stem:["DR" = 1/2 (E_("max") - E_("min"))//Z] ^| (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"]) |
 | Rated output ^| (stem:["unitsml(mV/V)"] or counts) |
 | Input impedance footnote:[mandatory for strain gauge load cells] ^| stem:["unitsml(Ohm)"] |
 | Cable connection footnote:[mandatory for strain gauge load cells] | ^| 4-wire / 6-wire
@@ -332,10 +332,10 @@ Additional information concerning the type (connection equipment, interfaces, et
 2+| Loading designation: (refer to R 60-1, 6.2.4.2)
 
 Tension  Compression  Universal  Beam (shear)  Beam (bending)
-| Minimum dead load as: stem:[E_{"min"} =] |
-| Safe load limit as: stem:[E_{"lim"} =] |
+| Minimum dead load as: stem:[E_("min") =] |
+| Safe load limit as: stem:[E_("lim") =] |
 | Excitation voltage: &#x2610; AC &#x2610; DC |
-| Value of the apportionment factor, stem:[p_{"LC"}], if not equal to 0.7 |
+| Value of the apportionment factor, stem:[p_("LC")], if not equal to 0.7 |
 |===
 
 ==== Additional information of the test pattern for digital load cells
@@ -346,7 +346,7 @@ Tension  Compression  Universal  Beam (shear)  Beam (bending)
 | Interfaces: |
 | Output signal: |
 | Software identification: |
-| Value of the apportionment factor, stem:[p_{"LC"}], if not equal to 0.7 |
+| Value of the apportionment factor, stem:[p_("LC")], if not equal to 0.7 |
 |===
 
 ==== Relevant photographs taken during the examinations and tests
@@ -395,17 +395,17 @@ Tension  Compression  Universal  Beam (shear)  Beam (bending)
 | 6.2.1           | Serial number                                                       | | | _Not applicable_
 | 6.2.1           | Year of production                                                  | | | _Not applicable_
 | 6.2.2 / 6.2.4.1 | Accuracy class(es) and their symbols                                | | |
-| 6.2.4.5         | Maximum number of load cell verification intervals, stem:[n_{"LC"}] | | |
+| 6.2.4.5         | Maximum number of load cell verification intervals, stem:[n_("LC")] | | |
 | 6.2.2 / 6.2.4.2 | Type of load                                                        | | |
 | 6.2.2 / 6.2.4.3 | Working temperature designation                                     | | |
 | 6.2.2 / 6.2.4.4 | Humidity symbol "NH"                                                | | |
 | 6.2.2 / 6.2.4.4 | Humidity symbol "SH"                                                | | |
 | 6.2.2 / 6.2.4.4 | No humidity symbol or "CH"                                          | | |
-| 6.2.2 | Minimum dead load, stem:[E_{"min"}] footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
-| 6.2.1 / 6.2.2 | Maximum capacity, stem:[E_{"max"}] footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
-| 6.2.2 | Safe load limit, stem:[E_{"lim"}] footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
-| 6.2.2 | Minimum load cell verification interval (stem:[v_{"min"}]) footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
-| 6.2.3, a | Relative stem:[v_{"min"}] (stem:[Y]) | | |
+| 6.2.2 | Minimum dead load, stem:[E_("min")] footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
+| 6.2.1 / 6.2.2 | Maximum capacity, stem:[E_("max")] footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
+| 6.2.2 | Safe load limit, stem:[E_("lim")] footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
+| 6.2.2 | Minimum load cell verification interval (stem:[v_("min")]) footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
+| 6.2.3, a | Relative stem:[v_("min")] (stem:[Y]) | | |
 | 6.2.3, b | Minimum dead load output return DR footnote:[in units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | | |
 | 6.2.3, b | Relative DR (stem:[Z]) | | |
 | 6.2.2, l | Rated output | | |
@@ -413,7 +413,7 @@ Tension  Compression  Universal  Beam (shear)  Beam (bending)
 | 6.2.2, l | Input impedance | | |
 | 6.2.2, l | Cable connection footnote:[e.g. 4-wire / 6-wire cable] | | |
 | 6.2.2, l | Cable length footnote:[mandatory for strain gauge load cells with 4-wire connection] | | |
-| 6.2.2, k | Apportionment factor, stem:[p_{"LC"}] (if not equal to 0.7) | | |
+| 6.2.2, k | Apportionment factor, stem:[p_("LC")] (if not equal to 0.7) | | |
 | 6.2.2, l 6.2.3, c | Further information | | |
 |===
 
@@ -438,12 +438,12 @@ Further load cell information given by the manufacturer:
 .2+| Model designation
 | Maximum capacity | Minimum dead load | Maximum number of load cell intervals | Minimum load cell verification interval | Minimum dead load output return
 
-| stem:[E_{"max"}] +
+| stem:[E_("max")] +
 (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])
-| stem:[E_{"min"}] +
+| stem:[E_("min")] +
 (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])
-| stem:[n_{"LC"}]
-| stem:[v_{"min"}] +
+| stem:[n_("LC")]
+| stem:[v_("min")] +
 (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])
 | DR (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])
 

--- a/sources/r060/3/sections/05-examination.adoc
+++ b/sources/r060/3/sections/05-examination.adoc
@@ -17,7 +17,7 @@ _(To be completed by the Evaluating Authority)_
 ^| 6.2.1 | Name or trademark of manufacturer | |
 ^| 6.2.1 | Manufacturer's own designation or load cell model | |
 ^| 6.2.1 | Serial number | |
-^| 6.2.1 | Maximum capacity, stem:[E_{"max"}] footnote:[In units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | |
+^| 6.2.1 | Maximum capacity, stem:[E_("max")] footnote:[In units of (stem:["unitsml(g)", "unitsml(kg)", "unitsml(t)"])] | |
 ^| 6.2.1 | Year of production | |
 ^| 6.2.1 | Type approval mark (if applicable) | |
 |===
@@ -32,16 +32,16 @@ _(To be completed by the Evaluating Authority)_
 | Yes | No
 
 ^| 6.2.4.1 | Accuracy classes and their symbols | | | |
-^| 6.2.4.5 | Maximum number of load cell verification intervals, stem:[n_{"LC"}] | | | |
+^| 6.2.4.5 | Maximum number of load cell verification intervals, stem:[n_("LC")] | | | |
 ^| 6.2.4.2 | Loading designation (if necessary) | | | |
 ^| 6.2.4.3 | Working temperature designation | | | |
 ^| 6.2.4.4 | Humidity symbol "NH" | | | |
 ^| 6.2.4.4 | Humidity symbol "SH" | | | |
-^| 6.2.2 | Minimum dead load, stem:[E_{"min"}] | | | |
-^| 6.2.2 | Safe load limit, stem:[E_{"lim"}] | | | |
-^| 5.1.3, 6.2.2 | Minimum load cell verification interval (stem:[v_{"min"}]) | | | |
+^| 6.2.2 | Minimum dead load, stem:[E_("min")] | | | |
+^| 6.2.2 | Safe load limit, stem:[E_("lim")] | | | |
+^| 5.1.3, 6.2.2 | Minimum load cell verification interval (stem:[v_("min")]) | | | |
 ^| 6.2.2 | Other pertinent conditions | | | |
-^| 3.7.2, 5.3.2 | Apportionment factor, stem:[p_{"LC"}] (if not equal to 0.7) | | | |
+^| 3.7.2, 5.3.2 | Apportionment factor, stem:[p_("LC")] (if not equal to 0.7) | | | |
 ^| 5.1.6 | Standard classification | | | |
 ^| 5.1.7 | Multiple classifications | | | |
 |===
@@ -54,7 +54,7 @@ _(To be completed by the Evaluating Authority)_
 | Yes | No
 
 ^| 5.6.3.1 | Humidity symbol "CH" | | | |
-^| 3.5.15 | Relative stem:[v_{"min"}, Y] | | | |
+^| 3.5.15 | Relative stem:[v_("min"), Y] | | | |
 ^| 3.5.14 | Relative stem:["DR", Z] | | | |
 |===
 
@@ -168,7 +168,7 @@ here if available):
 | | | | | |
 
 .4+| R 60-1, 5.5.2 / R 60-2, 2.10.3
-.4+| Minimum dead load output return (stem:[C_{"DR"}]) (see R 60-3, 2.1.5.4)
+.4+| Minimum dead load output return (stem:[C_("DR")]) (see R 60-3, 2.1.5.4)
 | | | | |
 | _(See <<note_6.1-1>>)_ +
 stem:["DR" =]
@@ -183,13 +183,13 @@ stem:["DR" =]
 stem:["DR" =]
 
 | R 60-1, 5.6.3.1 / R 60-2, 2.10.5
-| Humidity effects (stem:[CH_{"min"}]) +
+| Humidity effects (stem:[CH_("min")]) +
 (CH or no mark) +
 (see R 60-3, 2.1.7.1)
 | | | | | |
 
 | R 60-1, 5.6.3.1 / R 60-2, 2.10.5
-| Humidity effects (stem:[CH_{"max"}]) +
+| Humidity effects (stem:[CH_("max")]) +
 (CH or no mark) +
 (see R 60-3, 2.1.7)
 | | | | | |
@@ -208,7 +208,7 @@ minimum dead load output +
 
 | R 60-1, 5.6.2 / R 60-2, 2.10.4
 | Barometric pressure +
-effects (stem:[C_P (v_{"min"})]) +
+effects (stem:[C_P (v_("min"))]) +
 (see R 60-3, 2.1.6)
 | | | _(See <<note_6.1-2>>)_ | | |
 
@@ -220,7 +220,7 @@ NOTE: DR is the minimum dead load output return in units of
 R 60-3, 2.1.5.8
 
 [[note_6.1-2]]
-NOTE: Maximum error in unit stem:[v_{"min"}]
+NOTE: Maximum error in unit stem:[v_("min")]
 
 Remarks:
 
@@ -322,7 +322,7 @@ Unit (e.g. counts, digits, g, kg, t) in which the measurement result is displaye
 | | | | 2+| Fulfils requirements
 | Test procedure +
 (R 60-2 reference)
-| stem:[D_{"max"}] | stem:[D_{"min"}]
+| stem:[D_("max")] | stem:[D_("min")]
 | Conversion factor, stem:[f ["indication" // v]] +
 (see R 60-3, 2.1.2.4)
 | Yes | No
@@ -343,29 +343,29 @@ Unit (e.g. counts, digits, g, kg, t) in which the measurement result is displaye
 (see R 60-2, 2.8.1)
 
 (To ensure that these requirements are met, the calculations should be carried out
-using lower stem:[n] values than the stem:[n_{"LC"}] specified. The calculations
+using lower stem:[n] values than the stem:[n_("LC")] specified. The calculations
 made do not include the application of 2.8.1).
 
 Check that
 
 [stem%unnumbered]
 ++++
-v_{"min"} <= {D_{"max"} - D_{"min"}} / n
+v_("min") <= {D_("max") - D_("min")} / n
 ++++
 
-It should be sufficient to carry out the calculations with stem:[n = n_{"LC"}],
-stem:[n_{"max"} - 500] and stem:[n = n_{"LC"} - 1000] if applicable.
+It should be sufficient to carry out the calculations with stem:[n = n_("LC")],
+stem:[n_("max") - 500] and stem:[n = n_("LC") - 1000] if applicable.
 
 [cols="10",options="header,unnumbered",headerrows=3]
 |===
 .3+| Test procedure (R 60-2 reference)
-.3+| stem:[D_{"min"}]
-.3+| stem:[D_{"max"}]
-.3+| stem:[n_{"LC"}]
-6+| Is the requirement stem:[v_{"min"} <= {D_{"max"} - D_{"min"}} / n] fulfilled with
-2+| stem:[n_{"LC"}]
-2+| stem:[n_{"LC"} - 500]
-2+| stem:[n_{"LC"} - 1000]
+.3+| stem:[D_("min")]
+.3+| stem:[D_("max")]
+.3+| stem:[n_("LC")]
+6+| Is the requirement stem:[v_("min") <= {D_("max") - D_("min")} / n] fulfilled with
+2+| stem:[n_("LC")]
+2+| stem:[n_("LC") - 500]
+2+| stem:[n_("LC") - 1000]
 | Yes | No | Yes | No | Yes | No
 
 ^| 2.10.1 | | .7+| | | | | | |
@@ -598,7 +598,7 @@ Reference indication at 75 % test load: input:text[]
 
 [form]
 --
-Minimum test load, stem:[D_{"min"}]: input:text[] PASS: input:checkbox[] FAIL: input:checkbox[]
+Minimum test load, stem:[D_("min")]: input:text[] PASS: input:checkbox[] FAIL: input:checkbox[]
 --
 
 [NOTE]
@@ -607,10 +607,10 @@ Minimum test load, stem:[D_{"min"}]: input:text[] PASS: input:checkbox[] FAIL: i
 interpolation between the adjacent higher and lower load point indications is used
 (see R 60-1, 5.3.1 and calculation procedures in R 60-3, 2.1.2.2).
 
-. Error, stem:[E_{"L"}]: the difference between the test indication and the reference
+. Error, stem:[E_("L")]: the difference between the test indication and the reference
 indication divided by the conversion factor, stem:[f].
 
-. Test load values are values above minimum test load, stem:[D_{"min"}].
+. Test load values are values above minimum test load, stem:[D_("min")].
 ====
 
 ===  Repeatability errors (stem:[E_R]) calculation
@@ -688,14 +688,14 @@ Conversion factor, stem:[f]: input:text[]
 | Change +
 (stem:[v])
 | Change +
-(stem:[v_{"min}] / . . . stem:["unitsml(degC)"])
+(stem:[v_("min)] / . . . stem:["unitsml(degC)"])
 | mpc +
-(stem:[v_{"min"}] / . . . stem:["unitsml(degC)"])
+(stem:[v_("min")] / . . . stem:["unitsml(degC)"])
 
 | | | | |
-| | | | ^| stem:[p_{"LC"}]
-| | | | ^| stem:[p_{"LC"}]
-| | | | ^| stem:[p_{"LC"}]
+| | | | ^| stem:[p_("LC")]
+| | | | ^| stem:[p_("LC")]
+| | | | ^| stem:[p_("LC")]
 |===
 
 [align=right]
@@ -707,14 +707,14 @@ PASS: &#x2610; FAIL: &#x2610;
 
 . Indication: the average initial minimum test load indication obtained from <<table-6.3>>.
 
-. The maximum permissible change (mpc) allowed is: (stem:[v_{"min"} // 5 "unitsml(degC)"])
-for classes B, C, and D; (stem:[v_{"min"} // 2 "unitsml(degC)"]) for class A.
+. The maximum permissible change (mpc) allowed is: (stem:[v_("min") // 5 "unitsml(degC)"])
+for classes B, C, and D; (stem:[v_("min") // 2 "unitsml(degC)"]) for class A.
 
-. Change, stem:[C_{"M"}] (stem:[v]): the difference between the observed indications,
+. Change, stem:[C_("M")] (stem:[v]): the difference between the observed indications,
 and the indications at the prior temperature, divided by the conversion factor, stem:[f].
 ====
 
-=== Creep (stem:[C_C]) and DR (stem:[C_{"DR"}])
+=== Creep (stem:[C_C]) and DR (stem:[C_("DR")])
 
 <<OIML_R_60_1,clause="5.5.1">>, <<OIML_R_60_1,clause="5.5.2">> +
 <<OIML_R_60_2,clause="2.10.2">>, <<OIML_R_60_2,clause="2.10.3.">> Complete one sheet for each test temperature.
@@ -737,9 +737,9 @@ Conversion factor, stem:[f]: input:text[]
 
 | | counts | hh:mm:ss | stem:["unitsml(kPa)"] | stem:[v] | mm:ss | stem:[v] | | counts | hh:mm:ss | stem:["unitsml(kPa)"] | stem:[v] | mm:ss | stem:[v]
 
-| stem:[D_{"min"}] | | | | | | | | | | | | |
+| stem:[D_("min")] | | | | | | | | | | | | |
 
-| stem:[D_{"max"}] | | | | | | | | | | | | |
+| stem:[D_("max")] | | | | | | | | | | | | |
 
 | | | | | | | | | | | | | |
 | | | | | | | | | | | | | |
@@ -747,15 +747,15 @@ Conversion factor, stem:[f]: input:text[]
 | | | | | | | | | | | | | |
 | | | | | | | | | | | | | |
 
-| (++*++) | | | | | | | stem:[D_{"max"}] | | | | | |
+| (++*++) | | | | | | | stem:[D_("max")] | | | | | |
 
-| stem:[D_{"min"}] | | | | | | | | | | | | |
+| stem:[D_("min")] | | | | | | | | | | | | |
 | | | | | | | | | | | | | |
 | | | | | | | | | | | | | |
 
 | | | | | | | | (++***++) | | | | | |
 
-| stem:[D_{"max"}] | | | | | | | stem:[D_{"min"}] | | | | | |
+| stem:[D_("max")] | | | | | | | stem:[D_("min")] | | | | | |
 
 | (++**++) | | | | | | | | | | | | |
 | | | | | | | | | | | | | |
@@ -846,9 +846,9 @@ hh:mm
 | Change +
 (stem:[v])
 | Change +
-(stem:[v_{"min}] / stem:["unitsml(kPa)"])
+(stem:[v_("min)] / stem:["unitsml(kPa)"])
 | mpc +
-(stem:[v_{"min"}] / stem:["unitsml(kPa)"])
+(stem:[v_("min")] / stem:["unitsml(kPa)"])
 
 | | | | 0 | 0 | 0
 | | | |   |   | 1
@@ -912,24 +912,24 @@ Conversion factor, stem:[f]: input:text[]
 | | | | | | |
 | | | | | | |
 
-5+| Average indication at stem:[D_{"min"}] (¤) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
-stem:[C_{"Hmin"} =] ← stem:[< 4 % n_{"LC"}] | |
+5+| Average indication at stem:[D_("min")] (¤) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+stem:[C_("Hmin") =] ← stem:[< 4 % n_("LC")] | |
 
-5+| Average indication at stem:[D_{"max"}] (‡) | |
+5+| Average indication at stem:[D_("max")] (‡) | |
 
-5+| Average difference (*) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; stem:[C_{"Hmax"} =]
+5+| Average difference (*) &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; stem:[C_("Hmax") =]
 | | 1
 |===
 
 (¤) Indications at minimum test load
 
-Change (¤), stem:[C_{"Hmin"}]: PASS: &#x2610; FAIL: &#x2610;
+Change (¤), stem:[C_("Hmin")]: PASS: &#x2610; FAIL: &#x2610;
 
 (‡) Indications at maximum test load <<note_3>>
 
 (++*++) Average, see R 60-1, 5.6.3 and R 60-3, 2.1.7
 
-Change (++*++), stem:[C_{"Hmax"}]: PASS: &#x2610; FAIL: &#x2610;
+Change (++*++), stem:[C_("Hmax")]: PASS: &#x2610; FAIL: &#x2610;
 
 [NOTE]
 ====
@@ -1219,7 +1219,7 @@ as appropriate to record individual teat results.
 2+| …. stem:["unitsml(degC)"] (stem:[20 "unitsml(degC)"]) …. % (50 %) RH 2+| …. stem:["unitsml(degC)"] (High) …. % (85 %) RH 2+| …. stem:["unitsml(degC)"] (stem:[20 "unitsml(degC)"]) …. % (50 %) RH
 .2+| MPE stem:[v]
 
-| Indication (counts) | Error (stem:[E_{"L"}]) stem:[v] | Indication (counts) | Error (stem:[E_{"L"}]) stem:[v] | Indication (counts) | Error (stem:[E_{"L"}]) stem:[v]
+| Indication (counts) | Error (stem:[E_("L")]) stem:[v] | Indication (counts) | Error (stem:[E_("L")]) stem:[v] | Indication (counts) | Error (stem:[E_("L")]) stem:[v]
 
 | | | | | | | | |
 | | | | | | | | |
@@ -1250,10 +1250,10 @@ PASS: input:checkbox[] FAIL: input:checkbox[]
 line interpolation between the adjacent higher and lower load point indication is
 used.
 
-. Error, stem:[E_{"L"}]: the difference between the test reference and the reference
+. Error, stem:[E_("L")]: the difference between the test reference and the reference
 indication divided by the conversion factor, stem:[f].
 
-. Test load values are values above minimum test load, stem:[D_{"min"}].
+. Test load values are values above minimum test load, stem:[D_("min")].
 
 . Conditioning period: the time period for exercising the load cell.
 
@@ -1283,14 +1283,14 @@ Duration of disconnection before test: input:text[]
 
 [cols="11",options="header",headerrows=2]
 |===
-2.2+| 2+| Initial run 2+| After 5 min.  2+| After 15 min.  2+| After 30 min.  .2+| mpc stem:[v_{"min"}]
+2.2+| 2+| Initial run 2+| After 5 min.  2+| After 15 min.  2+| After 30 min.  .2+| mpc stem:[v_("min")]
 | Indication (counts) | Time hh:mm:ss | Indication (counts) | Time hh:mm:ss | Indication (counts) | Time hh:mm:ss | Indication (counts) | Time hh:mm:ss
 
-|        | stem:[D_{"min"}] | | | | | | | | |
-|        | stem:[D_{"max"}] | | | | | | | | |
+|        | stem:[D_("min")] | | | | | | | | |
+|        | stem:[D_("max")] | | | | | | | | |
 | Span   | Counts           | | | | | | | | |
-| Span   | stem:[v_{"min"}] | | | | | | | | |
-| Change | stem:[v_{"min"}] | | | | | | | | |
+| Span   | stem:[v_("min")] | | | | | | | | |
+| Change | stem:[v_("min")] | | | | | | | | |
 |===
 
 [align=right]
@@ -1305,7 +1305,7 @@ indication at maximum test load. All span errors (error at maximum test load min
 the error at minimum test load) shall be within the maximum permissible error during
 the 30 minute test.
 
-. The change of span must not exceed stem:[v_{"min"}].
+. The change of span must not exceed stem:[v_("min")].
 
 . Change: the difference between the span and the initial run span.
 
@@ -1345,12 +1345,12 @@ AC: input:checkbox[] DC: input:checkbox[]
 2+| Preloads
 | Indication (counts) | Time hh:mm:ss
 
-^| stem:[D_{"min"}] | |
-^| stem:[D_{"max"}] | |
-^| stem:[D_{"min"}] | |
-^| stem:[D_{"max"}] | |
-^| stem:[D_{"min"}] | |
-^| stem:[D_{"max"}] | |
+^| stem:[D_("min")] | |
+^| stem:[D_("max")] | |
+^| stem:[D_("min")] | |
+^| stem:[D_("max")] | |
+^| stem:[D_("min")] | |
+^| stem:[D_("max")] | |
 |===
 
 [NOTE]
@@ -1362,7 +1362,7 @@ in R 60-2 and calculation procedures in R 60-3, 2.1.2)
 . Error: the difference between the test indication and the reference indication
 divided by the conversion factor, stem:[f].
 
-. The change of span must not exceed stem:[v_{"min"}].
+. The change of span must not exceed stem:[v_("min")].
 
 . When a voltage range is marked, use the average value as the reference value and
 determine upper and lower values of applied voltage according to R 60-2, 2.10.7.4.
@@ -1377,14 +1377,14 @@ cease to function
 |===
 2.2+| 2+| Initial run with main voltage 2+| lower limit main voltage - 15 % 2+| upper limit +10 %
 .2+| mpc +
-stem:[v_{"min"}]
+stem:[v_("min")]
 | Indication (counts) | Time hh:mm:ss | Indication (counts) | Time hh:mm:ss | Indication (counts) | Time hh:mm:ss
 
-.2+|                  | stem:[D_{"min"}] | | | | | | .4+|
-   | stem:[D_{"max"}] |                  | | | | |
+.2+|                  | stem:[D_("min")] | | | | | | .4+|
+   | stem:[D_("max")] |                  | | | | |
    | Span             | Counts           | | | | | |
-   | Span             | stem:[v_{"min"}] | | | | | |
-   | Change           | stem:[v_{"min"}] | | | | | | |
+   | Span             | stem:[v_("min")] | | | | | |
+   | Change           | stem:[v_("min")] | | | | | | |
 |===
 
 [align=right]
@@ -1407,7 +1407,7 @@ include::../templates/form-5.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 
 Reference voltage range: input:text[] V
 --
@@ -1421,7 +1421,7 @@ Reference voltage range: input:text[] V
 (&nbsp; &nbsp;)
 .2+| Difference +
 (&nbsp; &nbsp;)
-2+| Significant fault stem:[> v_{"min"}]
+2+| Significant fault stem:[> v_("min")]
 | No | Yes (remarks)
 
 5+| Without disturbance | | | |
@@ -1455,7 +1455,7 @@ include::../templates/form-5.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 --
 
 [[table-6.14.1]]
@@ -1468,7 +1468,7 @@ Minimum test load, stem:[D_{"min"}]: input:text[]
 (&nbsp; &nbsp; &nbsp;)
 .2+| Difference +
 (stem:[v])
-2+| Significant fault stem:[> v_{"min"}]
+2+| Significant fault stem:[> v_("min")]
 | No | Yes (remarks)
 
 .9+|
@@ -1506,7 +1506,7 @@ include::../templates/form-5.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 --
 
 [[table-6.14.2]]
@@ -1520,7 +1520,7 @@ Minimum test load, stem:[D_{"min"}]: input:text[]
 .2+| Difference +
 (stem:[v])
 
-2+| Significant fault stem:[> v_{"min"}]
+2+| Significant fault stem:[> v_("min")]
 | No | Yes (remarks)
 
 .3+| 2+^| without disturbance | | | |
@@ -1573,7 +1573,7 @@ include::../templates/form-3.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 --
 
 [[table-6.15]]
@@ -1608,9 +1608,9 @@ Minimum test load, stem:[D_{"min"}]: input:text[]
 
 3+| Ambient temperature | stem:["unitsml(degC)"] | stem:["unitsml(degC)"] 2+| stem:[f]
 
-3+| Relative humidity | % | % 2+| stem:[D_{"min"}] [unit]
+3+| Relative humidity | % | % 2+| stem:[D_("min")] [unit]
 
-3+| Barometric Pressure | stem:["unitsml(kPa)"] | stem:["unitsml(kPa)"] 2+| stem:[D_{"max"}] [unit]
+3+| Barometric Pressure | stem:["unitsml(kPa)"] | stem:["unitsml(kPa)"] 2+| stem:[D_("max")] [unit]
 
 .2+|
 2+| Cycle phase | *Initial* 2+| *During exposure* 2+| *After*
@@ -1626,9 +1626,9 @@ Minimum test load, stem:[D_{"min"}]: input:text[]
 2+| reference | 2+| 2+|
 2+| indicated | 2+| 2+|
 
-| Error [stem:[v_{"min"}]] 2+| | 2+| 2+|
+| Error [stem:[v_("min")]] 2+| | 2+| 2+|
 
-3+| relative error [%] stem:[E_{"ii"}] | 2+| 2+|
+3+| relative error [%] stem:[E_("ii")] | 2+| 2+|
 
 | MPE [%] 2+| 5+|
 
@@ -1682,7 +1682,7 @@ include::../templates/form-5.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 
 input:checkbox[] Contact discharges
 
@@ -1712,7 +1712,7 @@ stem:[>= 10]
 (&nbsp; &nbsp;)
 .2+| Difference +
 (stem:[v])
-2+| Significant fault stem:[> v_{"min"}]
+2+| Significant fault stem:[> v_("min")]
 
 | No | Yes (remarks)
 
@@ -1749,7 +1749,7 @@ include::../templates/form-5.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 
 Polarity (see <<note-6.16.2-2>>):
 
@@ -1779,7 +1779,7 @@ stem:[>= 10]
 .2+| Difference +
 (stem:[v])
 
-2+| Significant fault stem:[> v_{"min"}]
+2+| Significant fault stem:[> v_("min")]
 | No | Yes (remarks)
 
 .4+|
@@ -1810,7 +1810,7 @@ stem:[>= 10]
 .2+| Difference +
 (stem:[v])
 
-2+| Significant fault stem:[> v_{"min"}]
+2+| Significant fault stem:[> v_("min")]
 | No | Yes (remarks)
 
 .4+|
@@ -1868,7 +1868,7 @@ include::../templates/form-5.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 
 Rate of sweep: input:text[]
 
@@ -1890,7 +1890,7 @@ Test load material: input:text[]
 .2+| Difference +
 (stem:[v])
 
-2+| Significant fault stem:[> v_{"min"}]
+2+| Significant fault stem:[> v_("min")]
 | No | Yes (remarks)
 
 4+^| without disturbance | | | |
@@ -1946,7 +1946,7 @@ include::../templates/form-5.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 
 Rate of sweep: input:text[]
 
@@ -1973,10 +1973,10 @@ Test load material: input:text[]
 .4+^.^| output gained
 .2+^.^| &#x2610;
 3+| using actual loads 2+|
-3+| Test load: 2+| stem:[f_{"l"} = quad quad quad "unitsml(MHz)"]
+3+| Test load: 2+| stem:[f_("l") = quad quad quad "unitsml(MHz)"]
 
-.2+^.^| &#x2610; 3+| simulating loading 2+| stem:[f_{"h"} = quad quad quad "unitsml(MHz)"]
-3+| using: 2+| RF voltage stem:[v_{"emf"}]
+.2+^.^| &#x2610; 3+| simulating loading 2+| stem:[f_("h") = quad quad quad "unitsml(MHz)"]
+3+| using: 2+| RF voltage stem:[v_("emf")]
 
 2+| Cable exposed 3+| 2+| Modulation % AM
 
@@ -1986,9 +1986,9 @@ Test load material: input:text[]
 
 3+| Ambient temperature | stem:["unitsml(degC)"] | stem:["unitsml(degC)"] 2+| stem:[f]
 
-3+| Relative humidity | % | % 2+| stem:[D_{"min"}] [unit]
+3+| Relative humidity | % | % 2+| stem:[D_("min")] [unit]
 
-3+| Barometric pressure | stem:["unitsml(kPa)"] | stem:["unitsml(kPa)"] 2+| stem:[D_{"max"}] [unit]
+3+| Barometric pressure | stem:["unitsml(kPa)"] | stem:["unitsml(kPa)"] 2+| stem:[D_("max")] [unit]
 
 .2+| *Frequency cycle* 2+| Cycle phase ^| *Initial* 2+^| *During exposure* 2+^| *After*
 
@@ -2000,7 +2000,7 @@ Test load material: input:text[]
 .2+| Quantity [unit] 2+| reference | 2+| 2+|
 2+| indicated | 2+| 2+|
 
-| Error [stem:[v_{"min"}]] 2+| | 2+| 2+|
+| Error [stem:[v_("min")]] 2+| | 2+| 2+|
 
 3+| relative error [%] stem:[E] | 2+| 2+|
 
@@ -2064,9 +2064,9 @@ include::../templates/form-3.adoc[]
 
 Conversion factor, stem:[f]: input:text[]
 
-Minimum test load, stem:[D_{"min"}]: input:text[]
+Minimum test load, stem:[D_("min")]: input:text[]
 
-Maximum test load, stem:[D_{"max"}]: input:text[]
+Maximum test load, stem:[D_("max")]: input:text[]
 --
 
 [NOTE]
@@ -2760,9 +2760,9 @@ include::../templates/form-3.adoc[]
 |===
 .2+| Measurement no.  2+| Span
 .2+| Variation +
-(stem:[v_{"min"}])
-.2+| Maximum allowable variation (stem:[v_{"min"}])
-| (&nbsp; &nbsp; &nbsp;) | (stem:[v_{"min"}])
+(stem:[v_("min")])
+.2+| Maximum allowable variation (stem:[v_("min")])
+| (&nbsp; &nbsp; &nbsp;) | (stem:[v_("min")])
 
 | 1 | | | |
 | 2 | | | |

--- a/sources/r060/3/templates/form-3.adoc
+++ b/sources/r060/3/templates/form-3.adoc
@@ -4,13 +4,13 @@ Load cell model: input:text[]
 
 Serial no.: input:text[]
 
-stem:[E_{"max"}]: input:text[]
+stem:[E_("max")]: input:text[]
 
-stem:[n_{"LC"}]: input:text[]
+stem:[n_("LC")]: input:text[]
 
-stem:[v_{"min"}]: input:text[]
+stem:[v_("min")]: input:text[]
 
-stem:[p_{"LC"}]: input:text[] DR: input:text[]
+stem:[p_("LC")]: input:text[] DR: input:text[]
 
 Force-generating system: input:text[]
 

--- a/sources/r060/3/templates/form-4.adoc
+++ b/sources/r060/3/templates/form-4.adoc
@@ -4,17 +4,17 @@ Load cell model: input:text[]
 
 Serial no.: input:text[]
 
-stem:[E_{"max"}]: input:text[] stem:[E_{"min"}]: input:text[]
+stem:[E_("max")]: input:text[] stem:[E_("min")]: input:text[]
 
-stem:[n_{"LC"}]: input:text[] stem:[p_{"LC"}]: input:text[]
+stem:[n_("LC")]: input:text[] stem:[p_("LC")]: input:text[]
 
 stem:[Y]: input:text[] stem:[Z]: input:text[]
 
-stem:[v_{"min"}]: input:text[] DR: input:text[]
+stem:[v_("min")]: input:text[] DR: input:text[]
 
 Force-generating system: input:text[]
 
-Test load:, stem:[D_{"max"}]: input:text[] stem:[D_{"min"}]: input:text[]
+Test load:, stem:[D_("max")]: input:text[] stem:[D_("min")]: input:text[]
 
 Indicating instrument: input:text[]
 

--- a/sources/r060/a/sections/ab-oiml-certificate.adoc
+++ b/sources/r060/a/sections/ab-oiml-certificate.adoc
@@ -10,13 +10,13 @@ with the following additional information:
 [cols="a,a,a,a,a",options="unnumbered,header"]
 |===
 | _Model designation_                     | | | |
-| Maximum capacity, stem:[E_{"max"}]      | | | |
+| Maximum capacity, stem:[E_("max")]      | | | |
 | Accuracy class                          | | | |
 | Maximum number of load cell             | | | |
-| verification intervals, stem:[n_{"LC"}] | | | |
+| verification intervals, stem:[n_("LC")] | | | |
 | Minimum load cell verification          | | | |
-| interval, stem:[v_{"min"}]              | | | |
-| Apportioning factor, stem:[p_{"LC"}]    | | | |
+| interval, stem:[v_("min")]              | | | |
+| Apportioning factor, stem:[p_("LC")]    | | | |
 |===
 
 Additional characteristics and identification, as applicable according to
@@ -53,19 +53,19 @@ to the certificate:
 
 | Classification | | C4 | | | |
 | Additional markings | | - | | | |
-| Maximum number of load cell verification intervals | stem:[n_{"LC"}] | stem:[4000] | | | |
-| Maximum capacity | stem:[E_{"max"}] | stem:[30000] | | | | stem:["unitsml(kg)"]
-| Minimum dead load, relative | stem:[E_{"min"} // E_{"max"}] | 0 | | | | %
-| Relative stem:[v_{"min"}] (ratio to minimum load cell verification interval) | stem:[Y = (E_{"max"} - E_{"min"}) // (v_{"min"})] | stem:[24000] | | | |
-| Relative DR (ratio to minimum dead load output return) | stem:[Z = (E_{"max"} - E_{"min"})// (2 xx DR)] | stem:[7500] | | | |
+| Maximum number of load cell verification intervals | stem:[n_("LC")] | stem:[4000] | | | |
+| Maximum capacity | stem:[E_("max")] | stem:[30000] | | | | stem:["unitsml(kg)"]
+| Minimum dead load, relative | stem:[E_("min") // E_("max")] | 0 | | | | %
+| Relative stem:[v_("min")] (ratio to minimum load cell verification interval) | stem:[Y = (E_("max") - E_("min")) // (v_("min"))] | stem:[24000] | | | |
+| Relative DR (ratio to minimum dead load output return) | stem:[Z = (E_("max") - E_("min"))// (2 xx DR)] | stem:[7500] | | | |
 | Rated output
-footnote:note1[For load cells with digital output this refers to the number of counts for stem:[E_{"max"}].]
+footnote:note1[For load cells with digital output this refers to the number of counts for stem:[E_("max")].]
 | | 2.5 | | | | stem:["unitsml(mV/V)"]
-footnote:note1[For load cells with digital output this refers to the number of counts for stem:[E_{"max"}].]
+footnote:note1[For load cells with digital output this refers to the number of counts for stem:[E_("max")].]
 | Maximum excitation voltage | | 30 | | | | stem:["unitsml(V)"]
-| Input impedance (for strain gauge load cells) | stem:[R_{"LC"}] | stem:[4000] | | | | stem:["unitsml(Ohm)"]
+| Input impedance (for strain gauge load cells) | stem:[R_("LC")] | stem:[4000] | | | | stem:["unitsml(Ohm)"]
 | Temperature rating | | -- 10/+ 40 | | | | stem:["unitsml(degC)"]
-| Safe overload, relative | stem:[E_{"lim"} // E_{"max"}] | 150 | | | | %
+| Safe overload, relative | stem:[E_("lim") // E_("max")] | 150 | | | | %
 | Cable length | | 3 | | | | stem:["unitsml(m)"]
 | Additional characteristics per <<OIML_R_60_1,clause="3.4.2">> and <<OIML_R_60_1,clause="5.1.5">>
 footnote:[For load cells with digital output this is not required.]

--- a/sources/r060/a/sections/ac-oiml-load-cells.adoc
+++ b/sources/r060/a/sections/ac-oiml-load-cells.adoc
@@ -29,19 +29,19 @@ section "6 Data sheet and dimensions" in this Annex).
 |===
 | Accuracy class | | C
 
-| Maximum number of load cell intervals stem:[n_{"LC"}] | | stem:[3000]
+| Maximum number of load cell intervals stem:[n_("LC")] | | stem:[3000]
 
 | Rated output | stem:["unitsml(mV/V)"] | 2
 
-| Maximum capacity stem:[E_{"max"}] | stem:["unitsml(kg)"] | 150 / 200 / 250 / 300 / 500 / 750
+| Maximum capacity stem:[E_("max")] | stem:["unitsml(kg)"] | 150 / 200 / 250 / 300 / 500 / 750
 
-| Minimum load cell verification interval stem:[v_{"min"} = (E_{"max"} - E_{"min"}) // Y] | stem:["unitsml(kg)"] | stem:[E_{"max"} // 15000]
+| Minimum load cell verification interval stem:[v_("min") = (E_("max") - E_("min")) // Y] | stem:["unitsml(kg)"] | stem:[E_("max") // 15000]
 
-| Minimum dead load output return stem:["DR" = 1//2 (E_{"max"} - E_{"min"})// Z] | stem:["unitsml(kg)"] | stem:[1//2 (E_{"max"} - E_{"min"}) // 5000]
+| Minimum dead load output return stem:["DR" = 1//2 (E_("max") - E_("min"))// Z] | stem:["unitsml(kg)"] | stem:[1//2 (E_("max") - E_("min")) // 5000]
 
 |===
 
-Dead load: xxx stem:[% cdot E_{"max"}]; Safe overload: xxx stem:[% cdot E_{"max"}]; Input impedance: xxx stem:["unitsml(Ohm)"]
+Dead load: xxx stem:[% cdot E_("max")]; Safe overload: xxx stem:[% cdot E_("max")]; Input impedance: xxx stem:["unitsml(Ohm)"]
 
 [[sec-C.3]]
 === Tests
@@ -95,7 +95,7 @@ Figure 2 - Name plate
 === Documentation
 
 ====
-* Test Report No. xxx; C3; stem:[Y = "xxx"]; stem:[Z = "xxx"]; stem:[E_{"max"} = "xxx" "unitsml(kg)"]; SN: xxx
+* Test Report No. xxx; C3; stem:[Y = "xxx"]; stem:[Z = "xxx"]; stem:[E_("max") = "xxx" "unitsml(kg)"]; SN: xxx
 
 * Datasheet No. Xxx
 
@@ -130,17 +130,17 @@ Specifications of the load cell family
 |===
 2+| Accuracy class according to OIML R 60 |                  | C
 | Rated output                            |                  | stem:["unitsml(mV/V)"]  | stem:[2.0 pm 0.2]
-| Maximum capacity                        | stem:[E_{"max"}] | stem:["unitsml(kg)"]    | 150 / 200 / 250 / 300 / 500 / 750
-| Max. number of load cell intervals      | stem:[n_{"LC"}]  |                         | stem:[3000]
-| Min. load cell verification interval    | stem:[v_{"min"}] | stem:["unitsml(kg)"]    | stem:[E_{"max"} // 15000]
-| Minimum dead load output return (MDLOR) | DR               | stem:["unitsml(kg)"]    | stem:[1//2 cdot E_{"max"} // 5000]
-| Minimum dead load                       |                  | stem:[% cdot E_{"max"}] | 0
-| Safe load limit                         |                  | stem:[% cdot E_{"max"}] | 150
-| Ultimate load                           |                  | stem:[% cdot E_{"max"}] | 300
-| Excitation voltage, recommended         | stem:[U_{"EXE"}] | V                       | 10-12 DC
+| Maximum capacity                        | stem:[E_("max")] | stem:["unitsml(kg)"]    | 150 / 200 / 250 / 300 / 500 / 750
+| Max. number of load cell intervals      | stem:[n_("LC")]  |                         | stem:[3000]
+| Min. load cell verification interval    | stem:[v_("min")] | stem:["unitsml(kg)"]    | stem:[E_("max") // 15000]
+| Minimum dead load output return (MDLOR) | DR               | stem:["unitsml(kg)"]    | stem:[1//2 cdot E_("max") // 5000]
+| Minimum dead load                       |                  | stem:[% cdot E_("max")] | 0
+| Safe load limit                         |                  | stem:[% cdot E_("max")] | 150
+| Ultimate load                           |                  | stem:[% cdot E_("max")] | 300
+| Excitation voltage, recommended         | stem:[U_("EXE")] | V                       | 10-12 DC
 | Excitation voltage, maximum             |                  | stem:["unitsml(V)"]     | 15 DC
-| Input resistance                        | stem:[R_{"LC"}]  | stem:["unitsml(Ohm)"]   | stem:[404 pm 10]
-| Output resistance                       | stem:[R_{"out"}] | stem:["unitsml(Ohm)"]   | stem:[350 pm 3]
+| Input resistance                        | stem:[R_("LC")]  | stem:["unitsml(Ohm)"]   | stem:[404 pm 10]
+| Output resistance                       | stem:[R_("out")] | stem:["unitsml(Ohm)"]   | stem:[350 pm 3]
 | Insulation resistance                   | RISO             | stem:["unitsml(MOhm)"]  | stem:[=> 2000]
 | Compensated temperature range           | stem:[T]         | stem:["unitsml(degC)"]  | stem:[-10...+40]
 | Load cell material                      |                  |                         | Aluminium

--- a/sources/r060/a/sections/ad-selection.adoc
+++ b/sources/r060/a/sections/ad-selection.adoc
@@ -11,44 +11,44 @@ of test samples out of a load cell family.
 === {blank}
 
 Assume a family consisting of three groups of load cells, differing in class, maximum
-number of load cell verification intervals, stem:[n_{"LC"}], and maximum capacities,
-stem:[E_{"max"}]. The capacities, stem:[E_{"max"}], overlap between the groups according
+number of load cell verification intervals, stem:[n_("LC")], and maximum capacities,
+stem:[E_("max")]. The capacities, stem:[E_("max")], overlap between the groups according
 to the following example:
 
 Group 1::
 +
 --
-Class C, stem:[n_{"LC"} = 6000], stem:[Y = 18000], stem:[Z = 6000]
+Class C, stem:[n_("LC") = 6000], stem:[Y = 18000], stem:[Z = 6000]
 
-stem:[E_{"max"}]:stem:[50 "unitsml(kg)"],stem:[100 "unitsml(kg)"], stem:[300 "unitsml(kg)"]
+stem:[E_("max")]:stem:[50 "unitsml(kg)"],stem:[100 "unitsml(kg)"], stem:[300 "unitsml(kg)"]
  and  stem:[500 "unitsml(kg)"]
 --
 
 Group 2::
 +
 --
-Class C, stem:[n_{"LC"} = 3000], stem:[Y = 12000], stem:[Z = 4000]
+Class C, stem:[n_("LC") = 3000], stem:[Y = 12000], stem:[Z = 4000]
 
-stem:[E_{"max"}]: stem:[100 "unitsml(kg)"], stem:[300 "unitsml(kg)"], stem:[500 "unitsml(kg)"],
+stem:[E_("max")]: stem:[100 "unitsml(kg)"], stem:[300 "unitsml(kg)"], stem:[500 "unitsml(kg)"],
 stem:[5000 "unitsml(kg)"], stem:[10 "unitsml(t)"], stem:[30 "unitsml(t)"] and stem:[50 "unitsml(t)"]
 --
 
 Group 3::
 +
 --
-Class B, stem:[n_{"LC"} = 10000], stem:[Y = 25000], stem:[Z = 10000]
+Class B, stem:[n_("LC") = 10000], stem:[Y = 25000], stem:[Z = 10000]
 
-stem:[E_{"max"}]: stem:[500 "unitsml(kg)"], stem:[1000 "unitsml(kg)"] and stem:[4000 "unitsml(kg)"]
+stem:[E_("max")]: stem:[500 "unitsml(kg)"], stem:[1000 "unitsml(kg)"] and stem:[4000 "unitsml(kg)"]
 --
 
 [[sec-D.2.1]]
-==== Summarise and sort the load cells with respect to stem:[E_{"max"}] and accuracy as follows:
+==== Summarise and sort the load cells with respect to stem:[E_("max")] and accuracy as follows:
 
 [cols="a,a,a,a,a,a,a,a,a,a,a,a",options="noheader,unnumbered"]
 |===
 | Class
 
-stem:[n_{"LC"}]
+stem:[n_("LC")]
 
 Group
 
@@ -64,11 +64,11 @@ stem:[Z]
 
 &#x200c;
 
-2+| stem:[E_{"max"}, "unitsml(kg)"]
+2+| stem:[E_("max"), "unitsml(kg)"]
 
 &#x200c;
 
-stem:[v_{"min"}, "unitsml(kg)"]
+stem:[v_("min"), "unitsml(kg)"]
 
 5+^| ++--->++ highest
 
@@ -214,7 +214,7 @@ stem:[0.16]
 |===
 | Class
 
-stem:[n_{"LC"}]
+stem:[n_("LC")]
 
 Group
 
@@ -230,11 +230,11 @@ stem:[Z]
 
 &#x200c;
 
-2+| stem:[E_{"max"}, "unitsml(kg)"]
+2+| stem:[E_("max"), "unitsml(kg)"]
 
 &#x200c;
 
-stem:[v_{"min"}, "unitsml(kg)"]
+stem:[v_("min"), "unitsml(kg)"]
 
 5+| ++--->++ highest
 
@@ -396,7 +396,7 @@ in the group have been considered.
 |===
 | Class
 
-stem:[n_{"LC"}]
+stem:[n_("LC")]
 
 Group
 
@@ -412,11 +412,11 @@ stem:[Z]
 
 &#x200c;
 
-2+| stem:[E_{"max"}, "unitsml(kg)"]
+2+| stem:[E_("max"), "unitsml(kg)"]
 
 &#x200c;
 
-stem:[v_{"min"}, "unitsml(kg)"]
+stem:[v_("min"), "unitsml(kg)"]
 
 5+| ++--->++ highest
 
@@ -573,7 +573,7 @@ been considered.
 |===
 | Class
 
-stem:[n_{"LC"}]
+stem:[n_("LC")]
 
 Group
 
@@ -589,11 +589,11 @@ stem:[Z]
 
 &#x200c;
 
-2+| stem:[E_{"max"}, "unitsml(kg)"]
+2+| stem:[E_("max"), "unitsml(kg)"]
 
 &#x200c;
 
-stem:[v_{"min"}, "unitsml(kg)"]
+stem:[v_("min"), "unitsml(kg)"]
 
 5+| ++--->++ highest
 
@@ -757,7 +757,7 @@ groups have been considered.
 |===
 | Class
 
-stem:[n_{"LC"}]
+stem:[n_("LC")]
 
 Group
 
@@ -773,11 +773,11 @@ stem:[Z]
 
 &#x200c;
 
-2+| stem:[E_{"max"}, "unitsml(kg)"]
+2+| stem:[E_("max"), "unitsml(kg)"]
 
 &#x200c;
 
-stem:[v_{"min"}, "unitsml(kg)"]
+stem:[v_("min"), "unitsml(kg)"]
 
 5+| ++--->++ highest
 
@@ -931,16 +931,16 @@ according to R 60-2, 2.4.3 it is presumed to comply the requirements of this Rec
 
 After completing steps <<sec-D.2.2;to!sec-D.2.5>> and identifying the load cells,
 compare load cells of the same capacity from different groups. Identify the load
-cells with the highest accuracy class and highest stem:[n_{"LC"}] in each group
+cells with the highest accuracy class and highest stem:[n_("LC")] in each group
 (see shaded portion of table below). For those load cells of the same capacity but
 from different groups, identify only the one with the highest accuracy class and
-stem:[n_{"LC"}] and lowest stem:[v_{"min"}].
+stem:[n_("LC")] and lowest stem:[v_("min")].
 
 [cols="a,a,a,a,a,a,a,a,a,a,a,a",options="unnumbered"]
 |===
 | Class
 
-stem:[n_{"LC"}]
+stem:[n_("LC")]
 
 Group
 
@@ -955,11 +955,11 @@ Z
 
 &#x200c;
 
-2+| stem:[E_{"max"}, "unitsml(kg)"]
+2+| stem:[E_("max"), "unitsml(kg)"]
 
 &#x200c;
 
-stem:[v_{"min"}, "unitsml(kg)"]
+stem:[v_("min"), "unitsml(kg)"]
 
 5+| ++--->++ highest
 
@@ -1097,20 +1097,20 @@ stem:[0.16]
 | | | |
 |===
 
-Inspect the values of stem:[v_{"min"}], stem:[Y], and stem:[Z] for all cells of the
+Inspect the values of stem:[v_("min")], stem:[Y], and stem:[Z] for all cells of the
 same capacity.
 
-If any load cell of the same capacity has a lower stem:[v_{"min"}] or higher stem:[Y]
+If any load cell of the same capacity has a lower stem:[v_("min")] or higher stem:[Y]
 than the identified load cell, that load cell (or load cells) is also liable for
 partial evaluation testing, specifically the conduct of additional temperature effect
-on minimum dead load, stem:[E_{"min"}] and barometric pressure effect tests.
+on minimum dead load, stem:[E_("min")] and barometric pressure effect tests.
 
 If any load cell of the same capacity has a higher stem:[Y] than the selected load
 cell, that load cell (or load cells) is also liable for partial evaluation testing,
 specifically the conduct of additional creep and DR tests.
 
 In this example, the *load cells identified above also have the best characteristics
-of lowest stem:[v_{"min"}], highest stem:[Y] and highest stem:[Z].* This is normally
+of lowest stem:[v_("min")], highest stem:[Y] and highest stem:[Z].* This is normally
 the case, but not always.
 
 [[sec-D.2.7]]
@@ -1118,26 +1118,26 @@ the case, but not always.
 
 If applicable, select the load cell for humidity testing in accordance with
 R 60-2, 2.4.5, that being the load cell with the most severe characteristics, for
-example the greatest value of stem:[n_{"LC"}] or the lowest value of stem:[v_{"min"}].
+example the greatest value of stem:[n_("LC")] or the lowest value of stem:[v_("min")].
 
-In this example, the load cell with the greatest value of stem:[n_{"LC"}] or the
-lowest value of stem:[v_{"min"}] is the same load cell, therefore select:
+In this example, the load cell with the greatest value of stem:[n_("LC")] or the
+lowest value of stem:[v_("min")] is the same load cell, therefore select:
 
 *B10 - stem:[500 "unitsml(kg)"]* (humidity test required)
 
 NOTE: The other B10 load cells also possess the same qualifications and are possible
 choices. The stem:[500 "unitsml(kg)"] load cell was chosen because it is the smallest
 of the applicable B10 capacities. Although the C6 - stem:[50 "unitsml(kg)"] load
-cell has the lowest stem:[v_{"min"}] of stem:[0.0028], the B10 load cells have the
-highest stem:[n_{"LC"}], highest accuracy class, and the highest stem:[Y] and stem:[Z].
+cell has the lowest stem:[v_("min")] of stem:[0.0028], the B10 load cells have the
+highest stem:[n_("LC")], highest accuracy class, and the highest stem:[Y] and stem:[Z].
 
 [[sec-D.2.8]]
 ==== {blank}
 
 If applicable, select the load cell for the additional tests to be performed on digital
 load cells in accordance with R 60-2, 2.4.6, that being the load cell with the most
-severe characteristics, for example the greatest value of stem:[n_{"max"}] or the
-lowest value of stem:[v_{"min"}].
+severe characteristics, for example the greatest value of stem:[n_("max")] or the
+lowest value of stem:[v_("min")].
 
 2+h| *D.2.9* Summarising, the load cells selected for test are:
 

--- a/sources/r129/1/sections/02-terminology.adoc
+++ b/sources/r129/1/sections/02-terminology.adoc
@@ -65,13 +65,13 @@ instrument that measures without the intervention of an operator
 
 measuring instrument having one dimensional measuring range for each axis which is divided into partial measuring ranges each with different scale intervals, with the measuring range determined automatically according to the dimension being measured
 
-==== maximum measuring speed stem:[(V_\mathrm{max})]
+==== maximum measuring speed stem:[(V_(max))]
 
 maximum speed at which the instrument will measure correctly
 
 NOTE: Only applicable to instruments where measurements are affected by means of relative movement between the object and the instrument.
 
-==== minimum measuring speed stem:[(V_\mathrm{min})]
+==== minimum measuring speed stem:[(V_(min))]
 
 minimum speed at which the instrument will measure correctly
 
@@ -103,7 +103,7 @@ length (L), width (W) or height (H), measured by the measuring instrument, of th
 [[section-dv]]
 ==== dimensional volume (Dim Vol or DV)
 
-volume of the smallest rectangular box which fully encloses the object, and is the product of the indicated values of length (L), width (W) and height (H) stem:[DV = L \times W \times H]
+volume of the smallest rectangular box which fully encloses the object, and is the product of the indicated values of length (L), width (W) and height (H) stem:[DV = L times W times H]
 
 ==== maximum dimension (Max)
 

--- a/sources/r129/1/sections/04-metrological-requirements.adoc
+++ b/sources/r129/1/sections/04-metrological-requirements.adoc
@@ -11,14 +11,14 @@ The lower limit of the minimum dimension for all values of the scale interval is
 |===
 |Scale interval (d) |Minimum dimension (Min) (lower limit)
 
-|stem:[d \leq] 2 cm |10 d
-|2 cm stem:[\lt] stem:[d \leq] 10 cm |20 d
-|10 cm stem:[\lt] d |50 d
+|stem:[d <=] 2 cm |10 d
+|2 cm stem:[<] stem:[d <=] 10 cm |20 d
+|10 cm stem:[<] d |50 d
 |===
 
 ==== Value of the mpe
 
-The mpe applicable to the measurement by the instrument of any of the three dimensions for initial and subsequent verification is stem:[\pm 1.0] d.
+The mpe applicable to the measurement by the instrument of any of the three dimensions for initial and subsequent verification is stem:[+- 1.0] d.
 
 ==== Value of the fault limit
 
@@ -62,15 +62,15 @@ Error of indication = Indication - Nominal dimensions of the test object
 
 Instruments shall be designed and manufactured such that they do not exceed the mpe when exposed to the following ranges of environmental conditions:
 
-. mains power voltage variations: stem:[-15\,\%] to stem:[+10\,\%] of nominal voltage;
+. mains power voltage variations: stem:[-15 %] to stem:[+10 %] of nominal voltage;
 
-. air temperature variations at the temperature limits stated in the descriptive markings; if no temperature limits are stated in the descriptive markings stem:[-10\,\text{°C}] to stem:[+40\,\text{°C}] applies;
+. air temperature variations at the temperature limits stated in the descriptive markings; if no temperature limits are stated in the descriptive markings stem:[-10 "unitsml(degC)"] to stem:[+40 "unitsml(degC)"] applies;
 
-. relative humidity of 85 % (non-condensing) at the high temperature limit of the instrument or stem:[40\,\text{°C}], whichever is lower.
+. relative humidity of 85 % (non-condensing) at the high temperature limit of the instrument or stem:[40 "unitsml(degC)"], whichever is lower.
 
 An electronic instrument powered by direct current shall either continue to function correctly or not indicate any quantity when the voltage is below the manufacturer's specified nominal voltage.
 
-If special temperature limits are stated in the descriptive markings, the range shall be at least stem:[30\,\text{°C}].
+If special temperature limits are stated in the descriptive markings, the range shall be at least stem:[30 "unitsml(degC)"].
 
 === Disturbances
 

--- a/sources/r129/1/sections/05-technical-requirements.adoc
+++ b/sources/r129/1/sections/05-technical-requirements.adoc
@@ -80,7 +80,7 @@ For each indication of a quantity only one unit of measurement for that quantity
 
 ==== Value of the scale interval
 
-The value of all scale intervals shall be in the form stem:[1, 2] or stem:[5 \times 10^n] where n is a positive or negative whole number or zero.
+The value of all scale intervals shall be in the form stem:[1, 2] or stem:[5 times 10^n] where n is a positive or negative whole number or zero.
 
 The value of the scale interval shall be:
 
@@ -90,9 +90,9 @@ The value of the scale interval shall be:
 
 [[value-of-scale-c]] . variable (for example multi-interval) on one or more axes provided that:
 
-** if all three axes are multi-interval, then stem:[d_{x1} = d_{y1} = d_{z1}], stem:[d_{x2} = d_{y2} = d_{z2}], stem:[\dots], stem:[d_{xr} = d_{yr} = d_{zr}];
+** if all three axes are multi-interval, then stem:[d_(x1) = d_(y1) = d_(z1)], stem:[d_(x2) = d_(y2) = d_(z2)], stem:[...], stem:[d_(xr) = d_(yr) = d_(zr)];
 
-** if two axes are multi-interval, for example x and y, and z is fixed, then stem:[d_{x1} = d_{y1}], stem:[d_{x2} = d_{y2}], stem:[\dots], stem:[d_{xr} = d_{yr}], and instrument limitations such as object size, placement, etc. are clearly marked to define how to operate the instrument; and
+** if two axes are multi-interval, for example x and y, and z is fixed, then stem:[d_(x1) = d_(y1)], stem:[d_(x2) = d_(y2)], stem:[...], stem:[d_(xr) = d_(yr)], and instrument limitations such as object size, placement, etc. are clearly marked to define how to operate the instrument; and
 
 ** if only one axis is multi-interval, for example x, and y and z are fixed, then stem:[d_y = d_z] and instrument limitations such as object size, placement, etc. are clearly marked to define how to operate the instrument.
 
@@ -124,7 +124,7 @@ Displaying, storing, transmitting or printing the quantity value of any dimensio
 
 For each partial measuring range, the following apply:
 
-. the value of the scale interval of every partial measuring range must be less than the value of the scale interval of the subsequent partial measuring range stem:[(d_1 < d_2 < d_3 < \dots < d_r)];
+. the value of the scale interval of every partial measuring range must be less than the value of the scale interval of the subsequent partial measuring range stem:[(d_1 < d_2 < d_3 < ... < d_r)];
 
 . the maximum dimension of every partial measuring range must be equal to the minimum dimension of the subsequent partial measuring range (Min = Min~1~, Max = Max~r~, Max~1~ = Min~2~, etc.);
 
@@ -205,11 +205,11 @@ Instruments shall be clearly and permanently marked, either directly on the inst
 
 . maximum and minimum dimensions for each axis in the form Max=... Min=...;
 
-. if measurements are affected by means of relative movement between the object and the instrument, the maximum and minimum measuring speeds for which the instrument will measure correctly in the form stem:[V_\mathrm{max} = \dots \text{m/s}], stem:[V_\mathrm{min} = \dots \text{m/s}];
+. if measurements are affected by means of relative movement between the object and the instrument, the maximum and minimum measuring speeds for which the instrument will measure correctly in the form stem:[V_(max) = ... "unitsml(m/s)"], stem:[V_(min) = ... "unitsml(m/s)"];
 
-. scale interval(s) for each axis and range (multi-interval) in the form stem:[d = \dots]; and
+. scale interval(s) for each axis and range (multi-interval) in the form stem:[d = ...]; and
 
-. temperature limits (if other than stem:[-10\,\text{°C}] to stem:[+40\,\text{°C}]).
+. temperature limits (if other than stem:[-10 "unitsml(degC)"] to stem:[+40 "unitsml(degC)"]).
 
 ==== Technical specifications
 
@@ -237,7 +237,7 @@ Provision shall be made for the application of a verification mark either on a n
 
 . the part on which the mark is located shall not be removable from the instrument without damaging the mark; and
 
-. the size of the space shall be sufficient to contain the marks applied by the verifying authority: for example an area of at least stem:[200\,\text{mm}^2].
+. the size of the space shall be sufficient to contain the marks applied by the verifying authority: for example an area of at least stem:[200 "unitsml(mm^2)"].
 
 NOTE: If technical reasons restrict or limit the verification mark(s) to be fixed only in a "hidden" place (e.g. when an instrument in combination with another device is integrated in other equipment) this can be accepted if these marks are easily accessible, and if there is a legible notice provided on the instrument at a clearly visible place that provides direction to these marks or if its location is defined in the OIML certificate and OIML test report.
 

--- a/sources/r129/2/sections/01-type-evaluation.adoc
+++ b/sources/r129/2/sections/01-type-evaluation.adoc
@@ -53,9 +53,9 @@ Laboratory tests shall be performed in accordance with any limitations of use ma
 
 The test shall be carried out using appropriate test objects of various sizes and of stable dimensions. The test objects shall be opaque, rigid and with flat faces and well defined straight edges. Test objects may consist of rectangular boxes with dimensions which are known to an expanded uncertainty (coverage factor k=2) of not more than one-third of the mpe. The dimensions shall also be checked to the same uncertainty when used at the extreme values of the influence factors. The dimensions of these objects shall lie within the range of values bounded by the minimum and maximum dimensions measurable by the instrument. All adjacent faces and edges shall be perpendicular to each other.
 
-The dimensions of the test object shall be stem:[\mathrm{N} \times d] where N is a whole number and d is the value of the scale interval. An acceptable tolerance for the product of stem:[\mathrm{N} \times d] is stem:[\pm 1/3] d. For the different scale intervals, namely stem:[1, 2] or stem:[5 \times 10^n], stem:[\mathrm{N} = 10, 20], etc. would be suitable as a test object for all. This is applicable for type evaluation and verification tests.
+The dimensions of the test object shall be stem:[N times d] where N is a whole number and d is the value of the scale interval. An acceptable tolerance for the product of stem:[N times d] is stem:[+- 1/3] d. For the different scale intervals, namely stem:[1, 2] or stem:[5 times 10^n], stem:[N = 10, 20], etc. would be suitable as a test object for all. This is applicable for type evaluation and verification tests.
 
-Instruments may be equipped with an extended indication device or mode which displays the indication with a scale interval equal to, or less than, 1/5 d. Where an instrument has such a feature, and that feature is used during type evaluation or verification, the dimensions of the test object are not restricted to stem:[\mathrm{N} \times d] provided that the dimensions of the test object are known to at least 1/5 d.
+Instruments may be equipped with an extended indication device or mode which displays the indication with a scale interval equal to, or less than, 1/5 d. Where an instrument has such a feature, and that feature is used during type evaluation or verification, the dimensions of the test object are not restricted to stem:[N times d] provided that the dimensions of the test object are known to at least 1/5 d.
 
 ==== Acceptable indications
 
@@ -85,7 +85,7 @@ For automatic instruments, tests at the maximum and minimum speeds of relative m
 
 ==== Tests for multi-interval instruments
 
-For multi-interval instruments, tests shall be performed for all values of the scale interval, i.e. stem:[d_1, d_2, \dots, d_r].
+For multi-interval instruments, tests shall be performed for all values of the scale interval, i.e. stem:[d_1, d_2, ..., d_r].
 
 ==== Tests for different surfaces
 

--- a/sources/r129/2/sections/aa-performance-tests.adoc
+++ b/sources/r129/2/sections/aa-performance-tests.adoc
@@ -326,7 +326,7 @@ NOTE: Values applicable for 50 Hz/60 Hz respectively.
 |Verification of compliance with the provisions in A.1.4 and R 129-1, 4.3 when an electrical burst is applied to the power line, input/output control circuits and communication lines.
 
 |Test procedure in brief
-|The EUT shall be subjected to electrical bursts of voltage spikes. The test shall be conducted under constant environmental conditions. The transient generator shall have an output impedance of 50 stem:[\Omega] and 1000 stem:[\Omega] and shall be adjusted before connecting the EUT. At least ten positive and ten negative randomly phased bursts of voltage spikes with a double exponential waveform shall be applied. Each spike shall have a rise time of 5 ns and a half amplitude duration of 50 ns. The burst length shall be 15 ms, the burst period (repetition time interval) shall be 300 ms.
+|The EUT shall be subjected to electrical bursts of voltage spikes. The test shall be conducted under constant environmental conditions. The transient generator shall have an output impedance of 50 stem:[Omega] and 1000 stem:[Omega] and shall be adjusted before connecting the EUT. At least ten positive and ten negative randomly phased bursts of voltage spikes with a double exponential waveform shall be applied. Each spike shall have a rise time of 5 ns and a half amplitude duration of 50 ns. The burst length shall be 15 ms, the burst period (repetition time interval) shall be 300 ms.
 
 |Test level
 |
@@ -335,7 +335,7 @@ The EUT shall be tested as specified in A.1.4 at the following amplitudes (peak 
 . 2 kV for power supply lines; and
 . 1 kV for input/output control circuits and communication lines.
 
-With a repetition frequency of the impulses of 5 kHz stem:[\pm] 20 %.
+With a repetition frequency of the impulses of 5 kHz stem:[+-] 20 %.
 
 |Acceptance criteria
 |If the instrument does not detect and react to a significant fault occurring as a consequence of the electrical bursts, then the fault shall not exceed the value defined in R 129-1, 2.3.7.
@@ -487,7 +487,7 @@ The EUT shall be tested as specified in A.1.4 at the following amplitudes (peak 
 |The test procedure involves the use of radio frequency EM current, simulating the influence of EM fields coupled or injected into the power ports and I/O ports of the EUT using coupling/decoupling devices as defined in the referred standard. The performance of the test equipment consisting of an RF generator, decoupling devices, attenuators, etc. shall be verified. The functional performance of the EUT is observed (e.g. displayed indications and/or error messages) while at least ten measurements are taken with the conducted radio-frequency fields applied.
 
 |Test level
-|The EUT shall be tested as specified in A.1.4 at a RF amplitude (50 stem:[\Omega]), 10 V (e.m.f), 80 % AM, 1 kHz sine wave over EM frequency range of 0.15-80 MHz.
+|The EUT shall be tested as specified in A.1.4 at a RF amplitude (50 stem:[Omega]), 10 V (e.m.f), 80 % AM, 1 kHz sine wave over EM frequency range of 0.15-80 MHz.
 
 |Acceptance criteria
 |If the instrument does not detect and react to a significant fault occurring as a consequence of the electromagnetic susceptibility of the instrument, then the fault shall not exceed the value defined in R 129-1, 2.3.7.

--- a/sources/r129/2/sections/ab-comparison-table.adoc
+++ b/sources/r129/2/sections/ab-comparison-table.adoc
@@ -13,7 +13,7 @@
 
 |1.1.2 |Software documentation | | |New requirements for software documentation to be submitted for type approval.
 
-|1.4.2 |Test objects |11.1.4.2 |Test objects |The dimensions of the test objects known to an expanded uncertainty - Changed to 1/3 mpe. An acceptable tolerance for the test objects for the product of stem:[N \times d] as stem:[\pm 1/3] d was specified. Requirements for test objects used on instruments with extended indication device.
+|1.4.2 |Test objects |11.1.4.2 |Test objects |The dimensions of the test objects known to an expanded uncertainty - Changed to 1/3 mpe. An acceptable tolerance for the test objects for the product of stem:[N times d] as stem:[+- 1/3] d was specified. Requirements for test objects used on instruments with extended indication device.
 
 |1.4.11 |Software evaluation | | |New requirements for software evaluation and evaluation methods.
 

--- a/sources/r129/3/sections/01-introduction.adoc
+++ b/sources/r129/3/sections/01-introduction.adoc
@@ -21,18 +21,18 @@ Meaning of symbols used in this report:
 stem:[L]:: Indicated length
 stem:[W]:: Indicated width
 stem:[H]:: Indicated height
-stem:[L_\mathrm{T}]:: Length of the test object
-stem:[DL]:: Error, stem:[L - L_\mathrm{T}]
-stem:[W_\mathrm{T}]:: Width of the test object
-stem:[DW]:: Error, stem:[W - W_\mathrm{T}]
-stem:[H_\mathrm{T}]:: Height of the test object
-stem:[DH]:: Error, stem:[H - H_\mathrm{T}]
+stem:[L_(T)]:: Length of the test object
+stem:[DL]:: Error, stem:[L - L_(T)]
+stem:[W_(T)]:: Width of the test object
+stem:[DW]:: Error, stem:[W - W_(T)]
+stem:[H_(T)]:: Height of the test object
+stem:[DH]:: Error, stem:[H - H_(T)]
 mpe:: Maximum permissible error
 stem:[V]:: Volume indicated on the instrument
-stem:[V_\mathrm{calc}]:: stem:[L \times W \times H]
+stem:[V_(calc)]:: stem:[L times W times H]
 stem:[F]:: Conversion factor
 DW:: Dimensional weight indicated on the instrument
-DWcalc:: stem:[V \times F]
+DWcalc:: stem:[V times F]
 SF:: Significant fault
 
 The name(s) or symbol(s) of the unit(s) used to express test results shall be specified on each form.

--- a/sources/r129/3/sections/02-type-evaluation-tests.adoc
+++ b/sources/r129/3/sections/02-type-evaluation-tests.adoc
@@ -164,7 +164,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 Initial zeroing (Ready condition): [ ] yes [ ] no
 
 |===
-|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -178,7 +178,7 @@ Initial zeroing (Ready condition): [ ] yes [ ] no
 |===
 
 |===
-|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -194,7 +194,7 @@ Initial zeroing (Ready condition): [ ] yes [ ] no
 Initial zeroing (Ready condition): [ ] yes [ ] no
 
 |===
-|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -210,7 +210,7 @@ Initial zeroing (Ready condition): [ ] yes [ ] no
 Initial zeroing (Ready condition): [ ] yes [ ] no
 
 |===
-|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -226,7 +226,7 @@ Initial zeroing (Ready condition): [ ] yes [ ] no
 Initial zeroing (Ready condition): [ ] yes [ ] no
 
 |===
-|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -242,7 +242,7 @@ Initial zeroing (Ready condition): [ ] yes [ ] no
 Initial zeroing (Ready condition): [ ] yes [ ] no
 
 |===
-|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Run (units) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -294,7 +294,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 |===
 
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | | |
 |2 | | | | | | | | | | | | |
@@ -347,7 +347,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 
 .High temperature
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | | |
 |2 | | | | | | | | | | | | |
@@ -358,7 +358,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 
 .Low temperature
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | | |
 |2 | | | | | | | | | | | | |
@@ -410,7 +410,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 |===
 
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | | |
 |2 | | | | | | | | | | | | |
@@ -466,7 +466,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 |===
 
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -518,7 +518,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 |===
 
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc
 
 |1 | | | | | | | | | | | |
 |2 | | | | | | | | | | | |
@@ -570,7 +570,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 |===
 
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | | |
 |2 | | | | | | | | | | | | |
@@ -697,7 +697,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 |===
 
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | | |
 |2 | | | | | | | | | | | | |
@@ -767,7 +767,7 @@ Conveyor speed (m/min): [ ] Minimum [ ] Maximum [ ] Other ___
 |===
 
 |===
-|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_\mathrm{calc}] |DW |DWcalc |Pass/Fail
+|Test object ID |Initial zeroing (yes/no) |L |stem:[ΔL] |W |stem:[ΔW] |H |stem:[ΔH] |mpe |stem:[V] |stem:[V_(calc)] |DW |DWcalc |Pass/Fail
 
 |1 | | | | | | | | | | | | |
 |2 | | | | | | | | | | | | |

--- a/sources/r129/4/sections/02-explanatory-notes.adoc
+++ b/sources/r129/4/sections/02-explanatory-notes.adoc
@@ -5,16 +5,16 @@ Meaning of symbols used in this report:
 stem:[L]:: Indicated length
 stem:[W]:: Indicated width
 stem:[H]:: Indicated height
-stem:[L_\mathrm{T}]:: Length of the test object
-stem:[DL]:: Error, stem:[L - L_\mathrm{T}]
-stem:[W_\mathrm{T}]:: Width of the test object
-stem:[DW]:: Error, stem:[W - W_\mathrm{T}]
-stem:[H_\mathrm{T}]:: Height of the test object
-stem:[DH]:: Error, stem:[H - H_\mathrm{T}]
+stem:[L_(T)]:: Length of the test object
+stem:[DL]:: Error, stem:[L - L_(T)]
+stem:[W_(T)]:: Width of the test object
+stem:[DW]:: Error, stem:[W - W_(T)]
+stem:[H_(T)]:: Height of the test object
+stem:[DH]:: Error, stem:[H - H_(T)]
 mpe:: Maximum permissible error
 stem:[V]:: Volume indicated on the instrument
-stem:[V_\mathrm{calc}]:: stem:[L \times W \times H]
+stem:[V_(calc)]:: stem:[L times W times H]
 stem:[F]:: Conversion factor
 DW:: Dimensional weight indicated on the instrument
-DWcalc:: stem:[V \times F]
+DWcalc:: stem:[V times F]
 SF:: Significant fault

--- a/sources/r129/4/sections/11-checklist.adoc
+++ b/sources/r129/4/sections/11-checklist.adoc
@@ -35,7 +35,7 @@ Observer: ___
 |Value of mpe
 | | |
 
-| |mpe applicable to any of the three dimensions = stem:[\pm]1.0 stem:[d]
+| |mpe applicable to any of the three dimensions = stem:[+-]1.0 stem:[d]
 | | |
 
 |4.1.3
@@ -288,7 +288,7 @@ Observer: ___
 |Value of scale interval
 | | |
 
-| |Value of scale interval in the form stem:[1, 2] or stem:[5 \times 10^n]
+| |Value of scale interval in the form stem:[1, 2] or stem:[5 times 10^n]
 | | |
 
 | |The scale interval shall be:

--- a/sources/r144/2/sections/01-performance-tests.adoc
+++ b/sources/r144/2/sections/01-performance-tests.adoc
@@ -43,7 +43,7 @@ the formula:
 
 [stem%unnumbered]
 ++++
-s = sqrt{(sum_{i=1}^n (Y_i - bar Y)^2) / (n - 1)}
+s = sqrt{(sum_(i=1)^n (Y_i - bar Y)^2) / (n - 1)}
 ++++
 
 where:


### PR DESCRIPTION
Convert all LaTeX math syntax inside `stem:[...]` blocks to proper AsciiMath notation across 27 files in d011-e13, r060, r129, and r144.

## Conversions applied

| LaTeX pattern | AsciiMath equivalent | Files affected |
|---|---|---|
| `\\mathrm{°C}`, `\\text{°C}` | `"unitsml(degC)"` | d011, r129 |
| `\\text{mm}^2` | `"unitsml(mm^2)"` | r129 |
| `\\text{m/s}` | `"unitsml(m/s)"` | r129 |
| `\\times` | `times` | r129, r144 |
| `\\pm` | `+-` | r129 |
| `\\Omega` | `Omega` | r129 |
| `\\dots` | `...` | r129 |
| `\\leq` | `<=` | r129 |
| `\\lt` | `<` | r129 |
| `\\,` (thin space) | space | d011, r129 |
| `\\%` | `%` | r129 |
| `_\\mathrm{X}` | `_(X)` | r129 |
| `\\mathrm{N}` | `N` | r129 |
| `_{X}` (curly brace subscript) | `_(X)` | r060, d011 |

Also fixes 3 pre-existing typos with unbalanced braces in r060/1 and r060/3.