### PR TITLE
feat(oiml-cs): migrate OIML-CS sources to the oiml-cs taste

### DIFF
--- a/sources/oiml-cs-cid-01/document.adoc
+++ b/sources/oiml-cs-cid-01/document.adoc
@@ -1,6 +1,6 @@
 = Clarifications and Interpretations of OIML-CS Documents
 :docidentifier: OIML-CS CID-01 Edition 6
-:doctype: oiml-cs-clarification-document
+:doctype: clarification-document
 :title-main-en: Clarifications and Interpretations of OIML-CS Documents
 :edition: 6
 :revdate: 2024-09-19
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-od-01/document.adoc
+++ b/sources/oiml-cs-od-01/document.adoc
@@ -1,6 +1,6 @@
 = Management Committee
 :docidentifier: OIML-CS OD-01 Edition 4
-:doctype: international-document
+:doctype: operational-document
 :title-main-en: Management Committee
 :edition: 4
 :revdate: 2024-03-11
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-od-02/document.adoc
+++ b/sources/oiml-cs-od-02/document.adoc
@@ -1,6 +1,6 @@
 = Test Laboratories Forum
 :docidentifier: OIML-CS OD-02 Edition 3
-:doctype: international-document
+:doctype: operational-document
 :title-main-en: Test Laboratories Forum
 :edition: 3
 :revdate: 2024-03-11
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-01/document.adoc
+++ b/sources/oiml-cs-pd-01/document.adoc
@@ -1,6 +1,6 @@
 = Appeals, Resolution of Complaints and Disputes
 :docidentifier: OIML-CS PD-01 Edition 3
-:doctype: international-document
+:doctype: procedural-document
 :title-main-en: Appeals, Resolution of Complaints and Disputes
 :edition: 3
 :revdate: 2024-08-26
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-02/document.adoc
+++ b/sources/oiml-cs-pd-02/document.adoc
@@ -1,6 +1,6 @@
 = Approval of Legal Metrology Experts and Management System Experts
 :docidentifier: OIML-CS PD-02 Edition 3
-:doctype: international-document
+:doctype: procedural-document
 :title-main-en: Approval of Legal Metrology Experts and Management System Experts
 :edition: 3
 :revdate: 2022-11-14
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-03/document.adoc
+++ b/sources/oiml-cs-pd-03/document.adoc
@@ -1,6 +1,6 @@
 = Application and approval of OIML Issuing Authorities
 :docidentifier: OIML-CS PD-03 Edition 5
-:doctype: international-document
+:doctype: procedural-document
 :title-main-en: Application and approval of OIML Issuing Authorities
 :edition: 5
 :revdate: 2025-12-24
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-04/document.adoc
+++ b/sources/oiml-cs-pd-04/document.adoc
@@ -1,6 +1,6 @@
 = Assessment and approval of Test Laboratories
 :docidentifier: OIML-CS PD-04 Edition 5
-:doctype: international-document
+:doctype: procedural-document
 :title-main-en: Assessment and approval of Test Laboratories
 :edition: 5
 :revdate: 2025-12-24
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-05/document.adoc
+++ b/sources/oiml-cs-pd-05/document.adoc
@@ -1,6 +1,6 @@
 = Processing an application for an OIML Type Evaluation Report and OIML Certificate
 :docidentifier: OIML-CS PD-05 Edition 6 (Amendment 1)
-:doctype: oiml-cs-procedural-document
+:doctype: procedural-document
 :title-main-en: Processing an application for an OIML Type Evaluation Report and OIML Certificate
 :edition: 6
 :revdate: 2024-08-27
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-06/document.adoc
+++ b/sources/oiml-cs-pd-06/document.adoc
@@ -1,6 +1,6 @@
 = Use of OIML Type Evaluation Reports and OIML Certificates
 :docidentifier: OIML-CS PD-06 Edition 4
-:doctype: oiml-cs-procedural-document
+:doctype: procedural-document
 :title-main-en: Use of OIML Type Evaluation Reports and OIML Certificates
 :edition: 4
 :revdate: 2024-03-11
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-07/document.adoc
+++ b/sources/oiml-cs-pd-07/document.adoc
@@ -1,6 +1,6 @@
 = Transition Arrangements under the OIML-CS
 :docidentifier: OIML-CS PD-07 Edition 4
-:doctype: international-document
+:doctype: procedural-document
 :title-main-en: Transition Arrangements under the OIML-CS
 :edition: 4
 :revdate: 2024-01-16
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-08/document.adoc
+++ b/sources/oiml-cs-pd-08/document.adoc
@@ -1,6 +1,6 @@
 = Signing a Declaration
 :docidentifier: OIML-CS PD-08 Edition 3
-:doctype: international-document
+:doctype: procedural-document
 :title-main-en: Signing a Declaration
 :edition: 3
 :revdate: 2024-03-11
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:

--- a/sources/oiml-cs-pd-09/document.adoc
+++ b/sources/oiml-cs-pd-09/document.adoc
@@ -1,6 +1,6 @@
 = Utilizers and Associates
 :docidentifier: OIML-CS PD-09 Edition 1
-:doctype: international-document
+:doctype: procedural-document
 :title-main-en: Utilizers and Associates
 :edition: 1
 :revdate: 2025-12-24
@@ -8,7 +8,7 @@
 :language: en
 :docstage: 60
 :docsubstage: 60
-:mn-document-class: oiml
+:mn-document-class: oiml-cs
 :mn-output-extensions: xml,html,pdf,rxl
 :imagesdir: images
 :local-cache-only:


### PR DESCRIPTION
## Summary

- Switch all 12 OIML-CS sources to `:mn-document-class: oiml-cs` and the matching taste doctypes:
  - PD-01..PD-09 → `procedural-document`
  - OD-01, OD-02 → `operational-document`
  - CID-01 → `clarification-document`
- Depends on the newly-merged `oiml-cs` taste in metanorma-taste (now on `main`).

## Test plan

- [x] `bundle exec metanorma sources/oiml-cs-*/document.adoc` builds cleanly for all 12 documents against `metanorma-taste@main` (post metanorma/metanorma-taste#175).
- [x] Outputs carry publisher `OIML-CS`, the OIML-CS logo, and doctype labels `Procedural Document` / `Operational Document` / `Clarification Document`.
- [x] Cross-references between OIML-CS documents resolve with the correct `OIML-CS` publisher prefix.
