### PR TITLE
add metanorma.test.yml CI smoke subset for the metanorma-cli release gate

### DIFF
--- a/metanorma.test.yml
+++ b/metanorma.test.yml
@@ -1,0 +1,12 @@
+---
+# Subset used by the metanorma-cli release smoke gate (metanorma-cli#391):
+# two documents covering both doctype families, small enough for CI.
+metanorma:
+  source:
+    files:
+      - sources/b018-e25/document.adoc
+      - sources/oiml-cs-pd-01/document.adoc
+
+  collection:
+    organization: "OIML"
+    name: "OIML sample documents (CI smoke subset)"


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-cli/issues/391

Adds the `metanorma.test.yml` CI smoke subset used by the metanorma-cli release gate (the shared samples job compiles this file instead of the full `metanorma.yml` when present). Two documents covering both doctype families; verified green under the exact CI invocation (`metanorma site generate -c metanorma.test.yml --strict`). Rationale and exclusion record in the issue comment: https://github.com/metanorma/metanorma-cli/issues/391#issuecomment-5060556275

🤖
